### PR TITLE
Enforce login before accessing dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,13 +18,14 @@ import Blank from "./pages/Blank";
 import AppLayout from "./layout/AppLayout";
 import { ScrollToTop } from "./components/common/ScrollToTop";
 import Home from "./pages/Dashboard/Home";
+import RequireAuth from "./components/auth/RequireAuth.jsx";
 export default function App() {
     return (<>
       <Router>
         <ScrollToTop />
         <Routes>
           {/* Dashboard Layout */}
-          <Route element={<AppLayout />}>
+          <Route element={<RequireAuth><AppLayout /></RequireAuth>}>
             <Route index path="/" element={<Home />}/>
 
             {/* Others Page */}

--- a/src/components/auth/RequireAuth.jsx
+++ b/src/components/auth/RequireAuth.jsx
@@ -1,0 +1,13 @@
+import { Navigate, useLocation } from "react-router";
+import { useAuth } from "../../context/AuthContext.jsx";
+
+export default function RequireAuth({ children }) {
+  const { token } = useAuth();
+  const location = useLocation();
+
+  if (!token) {
+    return <Navigate to="/signin" state={{ from: location }} replace />;
+  }
+
+  return children;
+}

--- a/src/components/auth/SignInForm.jsx
+++ b/src/components/auth/SignInForm.jsx
@@ -15,7 +15,7 @@ export default function SignInForm() {
         e.preventDefault();
         try {
             await auth.signIn(username, password);
-            navigate("/");
+            navigate("/self-scheduling-configurations");
         }
         catch (err) {
             console.error(err);


### PR DESCRIPTION
## Summary
- create a RequireAuth component for gating routes
- use RequireAuth around the dashboard routes
- redirect successful sign in to the SelfSchedulingConfiguration page

## Testing
- `npm run lint` *(fails: A config object is using the "globals" key, which is not supported in flat config system)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855af0acf748327b0ccf4beac453569