### PR TITLE
Remove unused pages and simplify sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router";
-import SignIn from "./pages/AuthPages/SignIn";
 import NotFound from "./pages/OtherPage/NotFound";
-import UserProfiles from "./pages/UserProfiles";
-import Videos from "./pages/UiElements/Videos";
-import Images from "./pages/UiElements/Images";
-import Alerts from "./pages/UiElements/Alerts";
-import Badges from "./pages/UiElements/Badges";
-import Avatars from "./pages/UiElements/Avatars";
-import Buttons from "./pages/UiElements/Buttons";
-import LineChart from "./pages/Charts/LineChart";
-import BarChart from "./pages/Charts/BarChart";
-import Calendar from "./pages/Calendar";
-import BasicTables from "./pages/Tables/BasicTables";
 import SelfSchedulingConfigurations from "./pages/SelfSchedulingConfigurations.jsx";
-import FormElements from "./pages/Forms/FormElements";
-import Blank from "./pages/Blank";
 import AppLayout from "./layout/AppLayout";
 import { ScrollToTop } from "./components/common/ScrollToTop";
 import Home from "./pages/Dashboard/Home";
@@ -26,34 +12,8 @@ export default function App() {
           {/* Dashboard Layout */}
           <Route element={<AppLayout />}>
             <Route index path="/" element={<Home />}/>
-
-            {/* Others Page */}
-            <Route path="/profile" element={<UserProfiles />}/>
-            <Route path="/calendar" element={<Calendar />}/>
-            <Route path="/blank" element={<Blank />}/>
-
-            {/* Forms */}
-            <Route path="/form-elements" element={<FormElements />}/>
-
-            {/* Tables */}
-            <Route path="/basic-tables" element={<BasicTables />}/>
             <Route path="/self-scheduling-configurations" element={<SelfSchedulingConfigurations />}/>
-
-            {/* Ui Elements */}
-            <Route path="/alerts" element={<Alerts />}/>
-            <Route path="/avatars" element={<Avatars />}/>
-            <Route path="/badge" element={<Badges />}/>
-            <Route path="/buttons" element={<Buttons />}/>
-            <Route path="/images" element={<Images />}/>
-            <Route path="/videos" element={<Videos />}/>
-
-            {/* Charts */}
-            <Route path="/line-chart" element={<LineChart />}/>
-            <Route path="/bar-chart" element={<BarChart />}/>
           </Route>
-
-          {/* Auth Layout */}
-          <Route path="/signin" element={<SignIn />}/>
 
           {/* Fallback Route */}
           <Route path="*" element={<NotFound />}/>

--- a/src/layout/AppSidebar.jsx
+++ b/src/layout/AppSidebar.jsx
@@ -1,76 +1,23 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router";
 // Assume these icons are imported from an icon library
-import { BoxCubeIcon, CalenderIcon, ChevronDownIcon, GridIcon, HorizontaLDots, ListIcon, PageIcon, PieChartIcon, PlugInIcon, TableIcon, UserCircleIcon, } from "../icons";
+import { ChevronDownIcon, GridIcon, HorizontaLDots, TaskIcon } from "../icons";
 import { useSidebar } from "../context/SidebarContext";
 import SidebarWidget from "./SidebarWidget";
 const navItems = [
     {
         icon: <GridIcon />,
         name: "Dashboard",
-        subItems: [{ name: "Ecommerce", path: "/", pro: false }],
+        subItems: [{ name: "Home", path: "/", pro: false }],
     },
     {
-        icon: <CalenderIcon />,
-        name: "Calendar",
-        path: "/calendar",
-    },
-    {
-        icon: <UserCircleIcon />,
-        name: "User Profile",
-        path: "/profile",
-    },
-    {
-        name: "Forms",
-        icon: <ListIcon />,
-        subItems: [{ name: "Form Elements", path: "/form-elements", pro: false }],
-    },
-    {
-        name: "Tables",
-        icon: <TableIcon />,
-        subItems: [
-            { name: "Basic Tables", path: "/basic-tables", pro: false },
-            { name: "Self Scheduling Configurations", path: "/self-scheduling-configurations", pro: false },
-        ],
-    },
-    {
-        name: "Pages",
-        icon: <PageIcon />,
-        subItems: [
-            { name: "Blank Page", path: "/blank", pro: false },
-            { name: "404 Error", path: "/error-404", pro: false },
-        ],
+        icon: <TaskIcon />,
+        name: "Self Scheduling Configurations",
+        path: "/self-scheduling-configurations",
     },
 ];
-const othersItems = [
-    {
-        icon: <PieChartIcon />,
-        name: "Charts",
-        subItems: [
-            { name: "Line Chart", path: "/line-chart", pro: false },
-            { name: "Bar Chart", path: "/bar-chart", pro: false },
-        ],
-    },
-    {
-        icon: <BoxCubeIcon />,
-        name: "UI Elements",
-        subItems: [
-            { name: "Alerts", path: "/alerts", pro: false },
-            { name: "Avatar", path: "/avatars", pro: false },
-            { name: "Badge", path: "/badge", pro: false },
-            { name: "Buttons", path: "/buttons", pro: false },
-            { name: "Images", path: "/images", pro: false },
-            { name: "Videos", path: "/videos", pro: false },
-        ],
-    },
-    {
-        icon: <PlugInIcon />,
-        name: "Authentication",
-        subItems: [
-            { name: "Sign In", path: "/signin", pro: false },
-        ],
-    },
-];
+
+const othersItems = [];
 const AppSidebar = () => {
     const { isExpanded, isMobileOpen, isHovered, setIsHovered } = useSidebar();
     const location = useLocation();
@@ -205,14 +152,16 @@ const AppSidebar = () => {
               </h2>
               {renderMenuItems(navItems, "main")}
             </div>
-            <div className="">
-              <h2 className={`mb-4 text-xs uppercase flex leading-[20px] text-gray-400 ${!isExpanded && !isHovered
+            {othersItems.length > 0 && (
+              <div className="">
+                <h2 className={`mb-4 text-xs uppercase flex leading-[20px] text-gray-400 ${!isExpanded && !isHovered
             ? "lg:justify-center"
             : "justify-start"}`}>
-                {isExpanded || isHovered || isMobileOpen ? ("Others") : (<HorizontaLDots />)}
-              </h2>
-              {renderMenuItems(othersItems, "others")}
-            </div>
+                  {isExpanded || isHovered || isMobileOpen ? ("Others") : (<HorizontaLDots />)}
+                </h2>
+                {renderMenuItems(othersItems, "others")}
+              </div>
+            )}
           </div>
         </nav>
         {isExpanded || isHovered || isMobileOpen ? <SidebarWidget /> : null}


### PR DESCRIPTION
## Summary
- trim app routes to only Home and Self Scheduling Configurations
- reduce sidebar to only the Home link and Self Scheduling Configurations as its own item

## Testing
- `npm run lint` *(fails: A config object is using the "globals" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_6855af51a28083278a3ce30ccf8b8b58