### PR TITLE
Replace unsupported datepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "react-helmet-async": "^2.0.5",
         "react-redux": "^9.2.0",
         "react-router": "^7.6.2",
-        "react-tailwindcss-datepicker": "^2.0.0",
         "swiper": "^11.2.8",
         "tailwind-merge": "^3.3.1"
       },
@@ -5414,16 +5413,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-tailwindcss-datepicker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-tailwindcss-datepicker/-/react-tailwindcss-datepicker-2.0.0.tgz",
-      "integrity": "sha512-HADddzZjeOIMxkKkueAyQmiAExLXYcwgPG0Qv1oP9cjCx4/jrhbbOAbazgjJmxfhGxUw7e0Goqs+DY3htKlhAA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "dayjs": "^1.11.12",
-        "react": "^17.0.2 || ^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/redux": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-helmet-async": "^2.0.5",
     "react-redux": "^9.2.0",
     "react-router": "^7.6.2",
-    "react-tailwindcss-datepicker": "^2.0.0",
     "swiper": "^11.2.8",
     "tailwind-merge": "^3.3.1"
   },

--- a/src/components/form/DateRangePicker.jsx
+++ b/src/components/form/DateRangePicker.jsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from "react";
-import Datepicker from "react-tailwindcss-datepicker";
 import Label from "./Label";
 
 export default function DateRangePicker({
@@ -10,30 +8,53 @@ export default function DateRangePicker({
   maxDate,
   ...props
 }) {
-  const [internalValue, setInternalValue] = useState(value);
+  const formatDate = (date) =>
+    date instanceof Date ? date.toISOString().split("T")[0] : "";
 
-  useEffect(() => {
-    setInternalValue(value);
-  }, [value]);
+  const parseDate = (str) => (str ? new Date(str) : null);
 
-  const handleChange = (val) => {
-    setInternalValue(val);
-    onChange?.(val);
+  const handleStartChange = (e) => {
+    onChange?.({
+      startDate: parseDate(e.target.value),
+      endDate: value.endDate,
+    });
   };
 
+  const handleEndChange = (e) => {
+    onChange?.({
+      startDate: value.startDate,
+      endDate: parseDate(e.target.value),
+    });
+  };
+
+  const inputClass =
+    "h-11 w-full rounded-lg border appearance-none px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:outline-hidden focus:ring-3 dark:bg-gray-900 dark:text-white/90 dark:placeholder:text-white/30 bg-transparent text-gray-800 border-gray-300 focus:border-brand-300 focus:ring-brand-500/20 dark:border-gray-700 dark:focus:border-brand-800";
+
+  const min = minDate ? formatDate(minDate) : undefined;
+  const max = maxDate ? formatDate(maxDate) : undefined;
+
   return (
-    <div>
+    <div {...props}>
       {label && <Label>{label}</Label>}
-      <Datepicker
-        value={internalValue}
-        onChange={handleChange}
-        useRange
-        asSingle={false}
-        minDate={minDate}
-        maxDate={maxDate}
-        displayFormat="YYYY-MM-DD"
-        {...props}
-      />
+      <div className="flex items-center gap-2">
+        <input
+          type="date"
+          value={formatDate(value.startDate)}
+          onChange={handleStartChange}
+          min={min}
+          max={max}
+          className={inputClass}
+        />
+        <span className="mx-1">-</span>
+        <input
+          type="date"
+          value={formatDate(value.endDate)}
+          onChange={handleEndChange}
+          min={min}
+          max={max}
+          className={inputClass}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- drop `react-tailwindcss-datepicker`
- implement a simple date range picker using two `<input type="date">` fields

## Testing
- `npm run lint` *(fails: React must be in scope)*

------
https://chatgpt.com/codex/tasks/task_e_685869c11e388327834fb2fd1c25c0fc