### PR TITLE
Improve configuration list UX

### DIFF
--- a/src/pages/SelfSchedulingConfigurations.jsx
+++ b/src/pages/SelfSchedulingConfigurations.jsx
@@ -47,13 +47,13 @@ export default function SelfSchedulingConfigurations() {
                   isHeader
                   className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
                 >
-                  City
+                  ID / Description
                 </TableCell>
                 <TableCell
                   isHeader
                   className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
                 >
-                  ID / Description
+                  Scheduling Window
                 </TableCell>
                 <TableCell
                   isHeader
@@ -65,7 +65,7 @@ export default function SelfSchedulingConfigurations() {
                   isHeader
                   className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
                 >
-                  Scheduling Window
+                  City
                 </TableCell>
                 <TableCell
                   isHeader
@@ -95,7 +95,6 @@ export default function SelfSchedulingConfigurations() {
                     key={cfg.id}
                     className={`${cfg.isRunning ? "border-l-4 border-green-500" : "bg-gray-50"}`}
                   >
-                    <TableCell className="px-5 py-4 text-start">{cfg.cityId}</TableCell>
                     <TableCell className="px-5 py-4 text-start">
                       <div className="leading-snug">
                         <div className="text-sm font-normal text-gray-500">{cfg.id}</div>
@@ -103,11 +102,12 @@ export default function SelfSchedulingConfigurations() {
                       </div>
                     </TableCell>
                     <TableCell className="px-5 py-4 text-start">
-                      {formatPeriod(cfg.toursPeriodStart, cfg.toursPeriodEnd)}
-                    </TableCell>
-                    <TableCell className="px-5 py-4 text-start">
                       {formatPeriod(cfg.schedulingWindowStart, cfg.schedulingWindowEnd)}
                     </TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      {formatPeriod(cfg.toursPeriodStart, cfg.toursPeriodEnd)}
+                    </TableCell>
+                    <TableCell className="px-5 py-4 text-start">{cfg.cityId}</TableCell>
                     <TableCell className="px-5 py-4 text-start">
                       {cfg.experienceIds && cfg.experienceIds.join(", ")}
                     </TableCell>

--- a/src/pages/SelfSchedulingConfigurations.jsx
+++ b/src/pages/SelfSchedulingConfigurations.jsx
@@ -17,7 +17,7 @@ import {
 import { PlayIcon, StopIcon } from "../icons";
 
 const formatPeriod = (start, end) =>
-  `${start?.replace(/-/g, "/"}) to ${end?.replace(/-/g, "/")}`;
+  `${(start || '').replace(/-/g, '/')} to ${(end || '').replace(/-/g, '/')}`;
 
 export default function SelfSchedulingConfigurations() {
   const dispatch = useDispatch();
@@ -158,7 +158,7 @@ export default function SelfSchedulingConfigurations() {
                     </TableCell>
                   </TableRow>
                 );
-              })
+              })}
             </TableBody>
           </Table>
         </div>

--- a/src/pages/SelfSchedulingConfigurations.jsx
+++ b/src/pages/SelfSchedulingConfigurations.jsx
@@ -2,13 +2,28 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PageBreadcrumb from "../components/common/PageBreadCrumb";
 import PageMeta from "../components/common/PageMeta";
-import { fetchConfigurations, openConfiguration, closeConfiguration } from "../store/configurationsSlice";
-import { Table, TableBody, TableCell, TableHeader, TableRow } from "../components/ui/table";
+import {
+  fetchConfigurations,
+  openConfiguration,
+  closeConfiguration,
+} from "../store/configurationsSlice";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "../components/ui/table";
 import { PlayIcon, StopIcon } from "../icons";
+
+const formatPeriod = (start, end) =>
+  `${start?.replace(/-/g, "/"}) to ${end?.replace(/-/g, "/")}`;
 
 export default function SelfSchedulingConfigurations() {
   const dispatch = useDispatch();
-  const { list, status, error } = useSelector((state) => state.configurations);
+  const { list, status, error, actionStatus } = useSelector(
+    (state) => state.configurations
+  );
 
   useEffect(() => {
     dispatch(fetchConfigurations({ pageSize: 10, pageNumber: 1, cityId: 1 }));
@@ -28,60 +43,122 @@ export default function SelfSchedulingConfigurations() {
           <Table>
             <TableHeader className="border-b border-gray-100 dark:border-white/[0.05]">
               <TableRow>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">ID</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">City</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Description</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Tours Start</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Tours End</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Schedule Start</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Schedule End</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Experiences</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Guides</TableCell>
-                <TableCell isHeader className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400">Actions</TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  City
+                </TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  ID / Description
+                </TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  Tours Period
+                </TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  Scheduling Window
+                </TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  Experiences
+                </TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  Guides
+                </TableCell>
+                <TableCell
+                  isHeader
+                  className="px-5 py-3 font-medium text-gray-500 text-start text-theme-xs dark:text-gray-400"
+                >
+                  Actions
+                </TableCell>
               </TableRow>
             </TableHeader>
             <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05]">
-              {list.map((cfg) => (
-                <TableRow
-                  key={cfg.id}
-                  className={`${cfg.isRunning ? "border-l-4 border-green-500" : "bg-gray-50"}`}
-                >
-                  <TableCell className="px-5 py-4 text-start">{cfg.id}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.cityId}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.description}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.toursPeriodStart}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.toursPeriodEnd}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.schedulingWindowStart}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.schedulingWindowEnd}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.experienceIds && cfg.experienceIds.join(", ")}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">{cfg.guideIds && cfg.guideIds.join(", ")}</TableCell>
-                  <TableCell className="px-5 py-4 text-start">
-                    {cfg.isRunning ? (
-                      <button
-                        onClick={() =>
-                          dispatch(
-                            closeConfiguration({ id: cfg.id })
-                          )
-                        }
-                        className="text-red-600"
-                      >
-                        <StopIcon className="inline-block" />
-                      </button>
-                    ) : (
-                      <button
-                        onClick={() =>
-                          dispatch(
-                            openConfiguration({ id: cfg.id })
-                          )
-                        }
-                        className="text-green-600"
-                      >
-                        <PlayIcon className="inline-block" />
-                      </button>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {list.map((cfg) => {
+                const loading = actionStatus[cfg.id] === "loading";
+                return (
+                  <TableRow
+                    key={cfg.id}
+                    className={`${cfg.isRunning ? "border-l-4 border-green-500" : "bg-gray-50"}`}
+                  >
+                    <TableCell className="px-5 py-4 text-start">{cfg.cityId}</TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      <div className="leading-snug">
+                        <div className="text-sm font-normal text-gray-500">{cfg.id}</div>
+                        <div className="text-brand-600 truncate">{cfg.description}</div>
+                      </div>
+                    </TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      {formatPeriod(cfg.toursPeriodStart, cfg.toursPeriodEnd)}
+                    </TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      {formatPeriod(cfg.schedulingWindowStart, cfg.schedulingWindowEnd)}
+                    </TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      {cfg.experienceIds && cfg.experienceIds.join(", ")}
+                    </TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      {cfg.guideIds && cfg.guideIds.join(", ")}
+                    </TableCell>
+                    <TableCell className="px-5 py-4 text-start">
+                      {loading ? (
+                        <svg
+                          className="inline-block h-4 w-4 animate-spin text-gray-500"
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          ></circle>
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                          ></path>
+                        </svg>
+                      ) : cfg.isRunning ? (
+                        <button
+                          onClick={() =>
+                            dispatch(closeConfiguration({ id: cfg.id }))
+                          }
+                          className="text-red-600"
+                        >
+                          <StopIcon className="inline-block" />
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() =>
+                            dispatch(openConfiguration({ id: cfg.id }))
+                          }
+                          className="text-green-600"
+                        >
+                          <PlayIcon className="inline-block" />
+                        </button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
             </TableBody>
           </Table>
         </div>

--- a/src/store/configurationsSlice.js
+++ b/src/store/configurationsSlice.js
@@ -77,6 +77,7 @@ const configurationsSlice = createSlice({
     list: [],
     status: "idle",
     error: null,
+    actionStatus: {},
   },
   reducers: {},
   extraReducers: (builder) => {
@@ -93,13 +94,27 @@ const configurationsSlice = createSlice({
         state.status = "failed";
         state.error = action.payload;
       })
+      .addCase(openConfiguration.pending, (state, action) => {
+        state.actionStatus[action.meta.arg.id] = "loading";
+      })
       .addCase(openConfiguration.fulfilled, (state, action) => {
         const cfg = state.list.find((c) => c.id === action.payload.id);
         if (cfg) cfg.isRunning = true;
+        state.actionStatus[action.payload.id] = "idle";
+      })
+      .addCase(openConfiguration.rejected, (state, action) => {
+        state.actionStatus[action.meta.arg.id] = "idle";
+      })
+      .addCase(closeConfiguration.pending, (state, action) => {
+        state.actionStatus[action.meta.arg.id] = "loading";
       })
       .addCase(closeConfiguration.fulfilled, (state, action) => {
         const cfg = state.list.find((c) => c.id === action.payload.id);
         if (cfg) cfg.isRunning = false;
+        state.actionStatus[action.payload.id] = "idle";
+      })
+      .addCase(closeConfiguration.rejected, (state, action) => {
+        state.actionStatus[action.meta.arg.id] = "idle";
       });
   },
 });


### PR DESCRIPTION
## Summary
- combine id and description into one column
- add formatted scheduling/tours period columns
- show spinner while waiting for open/close actions
- track per configuration action status in store

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6858c33cf0d883279de5dbee0a052cb8