### PR TITLE
Show schedulable tour items in configuration detail

### DIFF
--- a/src/components/ui/table/index.jsx
+++ b/src/components/ui/table/index.jsx
@@ -16,8 +16,12 @@ const TableRow = ({ children, className, handleClick }) => {
     return <tr onClick={handleClick} className={className}>{children}</tr>;
 };
 // TableCell Component
-const TableCell = ({ children, isHeader = false, className, }) => {
+const TableCell = ({ children, isHeader = false, className, ...props }) => {
     const CellTag = isHeader ? "th" : "td";
-    return <CellTag className={` ${className}`} >{children}</CellTag>;
+    return (
+        <CellTag className={` ${className}`} {...props}>
+            {children}
+        </CellTag>
+    );
 };
 export { Table, TableHeader, TableBody, TableRow, TableCell };


### PR DESCRIPTION
## Summary
- tweak TableCell to accept extra props so `colSpan` can be used
- load schedulable tour items on configuration detail page
- display a table listing each item with a header showing how long the configuration has been running or how long until start/close

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6858d713520083278e42dc5f274f9dcf