### PR TITLE
Add mock backend server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# When set to "true" all API requests are sent to the local mock server
+REACT_APP_USE_FAKE_SERVER=false
+# Optionally override the backend URL
+REACT_APP_BACKEND_URL=http://localhost:5005/api/v1

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ git clone https://github.com/TailAdmin/free-react-tailwind-admin-dashboard.git
    yarn dev
    ```
 
+### Using the mock backend
+
+This project includes a simple Express server located in the `mock-server` folder.
+Run it during development when the real backend is not available:
+
+```bash
+cd mock-server
+npm install
+npm start
+```
+
+Start the React app with the environment variable `REACT_APP_USE_FAKE_SERVER=true`
+to point all API requests to the mock server running on `http://localhost:3001`.
+
 ## Components
 
 TailAdmin is a pre-designed starting point for building a web-based dashboard using React.js and Tailwind CSS. The

--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -1,0 +1,14 @@
+# Mock Backend Server
+
+A simple Express server that provides fake responses for the frontend API.
+
+## Install and run
+
+```bash
+cd mock-server
+npm install
+npm start
+```
+
+The server listens on `http://localhost:3001` and exposes the same API used by the application under `/api/v1`.
+Set `REACT_APP_USE_FAKE_SERVER=true` when running the React app to use this mock backend.

--- a/mock-server/package.json
+++ b/mock-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mock-server",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/mock-server/server.js
+++ b/mock-server/server.js
@@ -1,0 +1,139 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+const router = express.Router();
+
+// Fake data generators
+let nextConfigId = 3;
+const cities = [
+  { id: 1, name: 'Rome' },
+  { id: 2, name: 'Milan' },
+  { id: 3, name: 'Florence' }
+];
+
+const tours = [
+  { id: 1, name: 'Colosseum Tour', cityId: 1 },
+  { id: 2, name: 'Vatican Museums', cityId: 1 },
+  { id: 3, name: 'Duomo Visit', cityId: 2 }
+];
+
+const guides = [
+  { guide: { id: 1, name: 'Mario Rossi' }, cityId: 1 },
+  { guide: { id: 2, name: 'Luigi Bianchi' }, cityId: 2 },
+  { guide: { id: 3, name: 'Anna Verdi' }, cityId: 1 }
+];
+
+let configurations = [
+  {
+    id: 1,
+    description: 'Summer Tours',
+    schedulingWindowStart: '2024-06-01',
+    schedulingWindowEnd: '2024-06-10',
+    toursPeriodStart: '2024-07-01',
+    toursPeriodEnd: '2024-07-31',
+    cityId: 1,
+    experienceIds: [1,2],
+    guideIds: [1],
+    isRunning: true
+  },
+  {
+    id: 2,
+    description: 'Winter Tours',
+    schedulingWindowStart: '2024-12-01',
+    schedulingWindowEnd: '2024-12-10',
+    toursPeriodStart: '2025-01-01',
+    toursPeriodEnd: '2025-01-31',
+    cityId: 2,
+    experienceIds: [3],
+    guideIds: [2],
+    isRunning: false
+  }
+];
+
+const items = [
+  { id: 1, name: 'Colosseum Tour', tourDate: '2024-07-10', availableSlots: 10, configurationId: 1 },
+  { id: 2, name: 'Vatican Museums', tourDate: '2024-07-11', availableSlots: 8, configurationId: 1 },
+  { id: 3, name: 'Duomo Visit', tourDate: '2025-01-15', availableSlots: 12, configurationId: 2 }
+];
+
+// Auth signin
+router.post('/auth/signin', (req, res) => {
+  res.json({ accessToken: 'fake-token' });
+});
+
+// Cities
+router.get('/cities', (req, res) => {
+  res.json(cities);
+});
+
+// Tours
+router.get('/tours', (req, res) => {
+  const { cityName } = req.query;
+  const filtered = cityName
+    ? tours.filter(t =>
+        cities.find(c => c.id === t.cityId)?.name.toLowerCase().includes(cityName.toLowerCase())
+      )
+    : tours;
+  res.json({ items: filtered });
+});
+
+// Guides
+router.get('/guides', (req, res) => {
+  const { cityId } = req.query;
+  const filtered = cityId ? guides.filter(g => g.cityId == cityId) : guides;
+  res.json({ items: filtered });
+});
+
+// List configurations
+router.get('/configurations', (req, res) => {
+  res.json(configurations);
+});
+
+// Create configuration
+router.post('/configuration', (req, res) => {
+  const newCfg = { id: nextConfigId++, ...req.body, isRunning: false };
+  configurations.push(newCfg);
+  res.json(newCfg);
+});
+
+// Get configuration by id
+router.get('/configurations/:id', (req, res) => {
+  const cfg = configurations.find(c => c.id == req.params.id);
+  if (!cfg) return res.status(404).end();
+  res.json(cfg);
+});
+
+// Open configuration
+router.post('/configurations/:id/open', (req, res) => {
+  const cfg = configurations.find(c => c.id == req.params.id);
+  if (!cfg) return res.status(404).end();
+  cfg.isRunning = true;
+  res.json({ id: cfg.id });
+});
+
+// Close configuration
+router.post('/configurations/:id/close', (req, res) => {
+  const cfg = configurations.find(c => c.id == req.params.id);
+  if (!cfg) return res.status(404).end();
+  cfg.isRunning = false;
+  res.json({ id: cfg.id });
+});
+
+// Items
+router.get('/items', (req, res) => {
+  const { configurationId } = req.query;
+  const filtered = configurationId ? items.filter(i => i.configurationId == configurationId) : items;
+  res.json({ items: filtered });
+});
+
+app.use('/api/v1', router);
+
+const PORT = 3001;
+app.listen(PORT, () => {
+  console.log(`Mock server running on port ${PORT}`);
+});

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -2,6 +2,11 @@ import { createContext, useContext, useState } from "react";
 
 const AuthContext = createContext({});
 
+const API_BASE_URL =
+  import.meta.env.REACT_APP_USE_FAKE_SERVER === "true"
+    ? "http://localhost:3001/api/v1"
+    : import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(() => localStorage.getItem("token") || "");
 
@@ -9,7 +14,7 @@ export const AuthProvider = ({ children }) => {
     const body = new URLSearchParams();
     body.append("userName", username);
     body.append("password", password);
-    const url = `http://localhost:5005/api/v1/auth/signin`;
+    const url = `${API_BASE_URL}/auth/signin`;
     const res = await fetch(url, {
       method: "POST",
       headers: {

--- a/src/pages/CreateSelfSchedulingConfiguration.jsx
+++ b/src/pages/CreateSelfSchedulingConfiguration.jsx
@@ -10,7 +10,10 @@ import MultiSelect from "../components/form/MultiSelect";
 import Button from "../components/ui/button/Button";
 
 const getToken = () => localStorage.getItem("token") || "";
-const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+const backend_url =
+  import.meta.env.REACT_APP_USE_FAKE_SERVER === "true"
+    ? "http://localhost:3001/api/v1"
+    : import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
 
 export default function CreateSelfSchedulingConfiguration() {
   const [cities, setCities] = useState([]);

--- a/src/pages/SelfSchedulingConfigurationDetails.jsx
+++ b/src/pages/SelfSchedulingConfigurationDetails.jsx
@@ -8,7 +8,10 @@ import { Table, TableBody, TableCell, TableHeader, TableRow } from "../component
 import { PlayIcon, StopIcon } from "../icons";
 
 const getToken = () => localStorage.getItem("token") || "";
-const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+const backend_url =
+  import.meta.env.REACT_APP_USE_FAKE_SERVER === "true"
+    ? "http://localhost:3001/api/v1"
+    : import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
 
 export default function SelfSchedulingConfigurationDetails() {
   const { id } = useParams();

--- a/src/store/configurationsSlice.js
+++ b/src/store/configurationsSlice.js
@@ -1,5 +1,10 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 
+const API_BASE_URL =
+  import.meta.env.REACT_APP_USE_FAKE_SERVER === "true"
+    ? "http://localhost:3001/api/v1"
+    : import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+
 export const fetchConfigurations = createAsyncThunk(
   "configurations/fetchConfigurations",
   async ({ pageSize = 10, pageNumber = 1, cityId } = {}, { rejectWithValue }) => {
@@ -9,9 +14,8 @@ export const fetchConfigurations = createAsyncThunk(
       if (pageNumber) params.append("pageNumber", pageNumber);
       if (cityId !== undefined) params.append("cityId", cityId);
       const token = getToken();
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
       const response = await fetch(
-        `${backend_url}/configurations?${params.toString()}`,
+        `${API_BASE_URL}/configurations?${params.toString()}`,
         {
           headers: {
             "Authorization": `Bearer ${token}`
@@ -33,8 +37,7 @@ export const openConfiguration = createAsyncThunk(
   async ({ id }, { rejectWithValue }) => {
     try {
       const token = getToken();
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
-      const url = `${backend_url}/configurations/${id}/open`;
+      const url = `${API_BASE_URL}/configurations/${id}/open`;
       const res = await fetch(url, {
         method: "POST",
         headers: { "Authorization": `Bearer ${token}` },
@@ -54,8 +57,7 @@ export const closeConfiguration = createAsyncThunk(
   async ({ id }, { rejectWithValue }) => {
     try {
       const token = getToken();
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
-      const url = `${backend_url}/configurations/${id}/close`;
+      const url = `${API_BASE_URL}/configurations/${id}/close`;
 
       const res = await fetch(url, {
         method: "POST",


### PR DESCRIPTION
## Summary
- add simple Express mock server under `mock-server`
- make backend url switchable using `REACT_APP_USE_FAKE_SERVER`
- update API calls to use the new variable
- document how to use the mock backend and sample environment variables

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6858eb26e9908327bcf81385a849cb03