### PR TITLE
Add signalR notifications for item slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-router": "^7.1.5",
     "swiper": "^11.2.3",
     "tailwind-merge": "^3.0.1",
+    "@microsoft/signalr": "^7.0.0",
     "vite-plugin-mkcert": "^1.17.8"
   },
   "devDependencies": {

--- a/src/context/NotificationContext.jsx
+++ b/src/context/NotificationContext.jsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useEffect, useRef } from "react";
+import { HubConnectionBuilder, LogLevel } from "@microsoft/signalr";
+import { useAuth } from "./AuthContext.jsx";
+
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+const hubUrl = backend_url.replace(/\/api\/v1\/?$/, "") + "/hubs/notifications";
+
+const NotificationContext = createContext(undefined);
+
+export const NotificationProvider = ({ children }) => {
+  const { token } = useAuth();
+  const connectionRef = useRef(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const connection = new HubConnectionBuilder()
+      .withUrl(hubUrl, { accessTokenFactory: () => token })
+      .withAutomaticReconnect()
+      .configureLogging(LogLevel.Warning)
+      .build();
+
+    connectionRef.current = connection;
+    connection.start().catch((err) => console.error("SignalR start error", err));
+
+    return () => {
+      connection.stop();
+    };
+  }, [token]);
+
+  const onAvailableSlotsUpdated = (handler) => {
+    if (connectionRef.current) {
+      connectionRef.current.on("AvailableSlotsUpdated", handler);
+    }
+  };
+
+  const offAvailableSlotsUpdated = (handler) => {
+    if (connectionRef.current) {
+      connectionRef.current.off("AvailableSlotsUpdated", handler);
+    }
+  };
+
+  return (
+    <NotificationContext.Provider value={{ onAvailableSlotsUpdated, offAvailableSlotsUpdated }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error("useNotifications must be used within a NotificationProvider");
+  }
+  return ctx;
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,17 +6,20 @@ import App from "./App.jsx";
 import { AppWrapper } from "./components/common/PageMeta.jsx";
 import { ThemeProvider } from "./context/ThemeContext.jsx";
 import { AuthProvider } from "./context/AuthContext.jsx";
+import { NotificationProvider } from "./context/NotificationContext.jsx";
 import { Provider } from "react-redux";
 import store from "./store/index.js";
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Provider store={store}>
       <AuthProvider>
-        <ThemeProvider>
-          <AppWrapper>
-            <App />
-          </AppWrapper>
-        </ThemeProvider>
+        <NotificationProvider>
+          <ThemeProvider>
+            <AppWrapper>
+              <App />
+            </AppWrapper>
+          </ThemeProvider>
+        </NotificationProvider>
       </AuthProvider>
     </Provider>
   </StrictMode>

--- a/src/pages/SelfSchedulingConfigurationDetails.jsx
+++ b/src/pages/SelfSchedulingConfigurationDetails.jsx
@@ -6,6 +6,7 @@ import Button from "../components/ui/button/Button";
 import useGoBack from "../hooks/useGoBack";
 import { Table, TableBody, TableCell, TableHeader, TableRow } from "../components/ui/table";
 import { PlayIcon, StopIcon } from "../icons";
+import { useNotifications } from "../context/NotificationContext.jsx";
 
 const getToken = () => localStorage.getItem("token") || "";
 const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
@@ -19,6 +20,7 @@ export default function SelfSchedulingConfigurationDetails() {
   const [items, setItems] = useState([]);
   const [itemsLoading, setItemsLoading] = useState(true);
   const [itemsError, setItemsError] = useState("");
+  const { onAvailableSlotsUpdated, offAvailableSlotsUpdated } = useNotifications();
 
   useEffect(() => {
     async function load() {
@@ -57,6 +59,18 @@ export default function SelfSchedulingConfigurationDetails() {
     }
     loadItems();
   }, [id]);
+
+  useEffect(() => {
+    const handler = ({ itemId, availableSlots }) => {
+      setItems((prev) =>
+        prev.map((it) =>
+          it.id === itemId ? { ...it, availableSlots } : it
+        )
+      );
+    };
+    onAvailableSlotsUpdated(handler);
+    return () => offAvailableSlotsUpdated(handler);
+  }, [onAvailableSlotsUpdated, offAvailableSlotsUpdated]);
 
   const handleAction = async (action) => {
     try {


### PR DESCRIPTION
## Summary
- add @microsoft/signalr dependency
- create NotificationContext to manage SignalR connection
- wrap App with NotificationProvider
- update SelfSchedulingConfigurationDetails page to update items when `AvailableSlotsUpdated` events arrive

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68590c44de4c8327b08979d4a86ea12d