### PR TITLE
Add Vercel API routes for mock backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=/api

--- a/api/auth/signin.js
+++ b/api/auth/signin.js
@@ -1,0 +1,14 @@
+import { users } from '../data.js';
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+  const { userName, password } = req.body || {};
+  const user = users.find(u => u.userName === userName && u.password === password);
+  if (!user) {
+    res.status(401).json({ message: 'Invalid credentials' });
+    return;
+  }
+  res.status(200).json({ accessToken: user.accessToken });
+}

--- a/api/cities.js
+++ b/api/cities.js
@@ -1,0 +1,4 @@
+import { cities } from './data.js';
+export default function handler(req, res) {
+  res.status(200).json(cities);
+}

--- a/api/configuration.js
+++ b/api/configuration.js
@@ -1,0 +1,17 @@
+import { configurations } from './data.js';
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  const body = req.body;
+  const newId = configurations.length ? Math.max(...configurations.map(c => c.id)) + 1 : 1;
+  const config = {
+    id: newId,
+    ...body,
+    isRunning: false
+  };
+  configurations.push(config);
+  res.status(200).json(config);
+}

--- a/api/configurations/[id].js
+++ b/api/configurations/[id].js
@@ -1,0 +1,10 @@
+import { configurations } from '../data.js';
+export default function handler(req, res) {
+  const { id } = req.query;
+  const config = configurations.find(c => String(c.id) === String(id));
+  if (!config) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  res.status(200).json(config);
+}

--- a/api/configurations/[id]/close.js
+++ b/api/configurations/[id]/close.js
@@ -1,0 +1,11 @@
+import { configurations } from '../../data.js';
+export default function handler(req, res) {
+  const { id } = req.query;
+  const cfg = configurations.find(c => String(c.id) === String(id));
+  if (!cfg) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  cfg.isRunning = false;
+  res.status(200).json(cfg);
+}

--- a/api/configurations/[id]/open.js
+++ b/api/configurations/[id]/open.js
@@ -1,0 +1,11 @@
+import { configurations } from '../../data.js';
+export default function handler(req, res) {
+  const { id } = req.query;
+  const cfg = configurations.find(c => String(c.id) === String(id));
+  if (!cfg) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  cfg.isRunning = true;
+  res.status(200).json(cfg);
+}

--- a/api/configurations/index.js
+++ b/api/configurations/index.js
@@ -1,0 +1,4 @@
+import { configurations } from '../data.js';
+export default function handler(req, res) {
+  res.status(200).json(configurations);
+}

--- a/api/data.js
+++ b/api/data.js
@@ -1,0 +1,41 @@
+export const cities = [
+  { id: 1, name: 'Rome' },
+  { id: 2, name: 'Milan' },
+  { id: 3, name: 'Florence' }
+];
+
+export const tours = [
+  { id: 1, name: 'Colosseum Tour', cityName: 'Rome' },
+  { id: 2, name: 'Duomo Tour', cityName: 'Milan' },
+  { id: 3, name: 'Uffizi Tour', cityName: 'Florence' }
+];
+
+export const guides = [
+  { guide: { id: 1, name: 'Mario Rossi' }, cityId: 1 },
+  { guide: { id: 2, name: 'Luigi Verdi' }, cityId: 2 },
+  { guide: { id: 3, name: 'Anna Bianchi' }, cityId: 3 }
+];
+
+export let configurations = [
+  {
+    id: 1,
+    cityId: 1,
+    description: 'Sample configuration',
+    schedulingWindowStart: '2025-01-01',
+    schedulingWindowEnd: '2025-01-07',
+    toursPeriodStart: '2025-02-01',
+    toursPeriodEnd: '2025-02-10',
+    experienceIds: [1],
+    guideIds: [1],
+    isRunning: false
+  }
+];
+
+export let items = [
+  { id: 1, configurationId: 1, name: 'Colosseum Morning', tourDate: '2025-02-01', availableSlots: 10 },
+  { id: 2, configurationId: 1, name: 'Colosseum Evening', tourDate: '2025-02-02', availableSlots: 8 }
+];
+
+export const users = [
+  { userName: 'admin', password: 'password', accessToken: 'mock-token' }
+];

--- a/api/guides.js
+++ b/api/guides.js
@@ -1,0 +1,6 @@
+import { guides } from './data.js';
+export default function handler(req, res) {
+  const { cityId } = req.query;
+  const filtered = cityId ? guides.filter(g => String(g.cityId) === String(cityId)) : guides;
+  res.status(200).json({ items: filtered });
+}

--- a/api/items.js
+++ b/api/items.js
@@ -1,0 +1,6 @@
+import { items } from './data.js';
+export default function handler(req, res) {
+  const { configurationId } = req.query;
+  const filtered = configurationId ? items.filter(i => String(i.configurationId) === String(configurationId)) : items;
+  res.status(200).json({ items: filtered });
+}

--- a/api/tours.js
+++ b/api/tours.js
@@ -1,0 +1,6 @@
+import { tours } from './data.js';
+export default function handler(req, res) {
+  const { cityName = '' } = req.query;
+  const filtered = cityName ? tours.filter(t => t.cityName.toLowerCase() === cityName.toLowerCase()) : tours;
+  res.status(200).json({ items: filtered });
+}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -9,7 +9,8 @@ export const AuthProvider = ({ children }) => {
     const body = new URLSearchParams();
     body.append("userName", username);
     body.append("password", password);
-    const url = `http://localhost:5005/api/v1/auth/signin`;
+    const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+    const url = `${backend_url}/auth/signin`;
     const res = await fetch(url, {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Summary
- patch AuthContext sign-in URL to use `REACT_APP_BACKEND_URL`
- add `.env` defaulting the backend URL to `/api`
- create a set of mock API routes under `api/` to handle cities, guides, tours, configurations and auth

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68590e5f05ac832797dc01bbf444912d