### PR TITLE
Refactor API calls to redux thunks

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,37 +1,17 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { signIn as signInThunk, signOut as signOutAction } from "../store/authSlice.js";
 
 const AuthContext = createContext({});
 
 export const AuthProvider = ({ children }) => {
-  const [token, setToken] = useState(() => localStorage.getItem("token") || "");
+  const dispatch = useDispatch();
+  const token = useSelector((state) => state.auth.token);
 
-  const signIn = async (username, password) => {
-    const body = new URLSearchParams();
-    body.append("userName", username);
-    body.append("password", password);
-    const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
-    const url = `${backend_url}/auth/signin`;
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: body.toString(),
-    });
-    if (!res.ok) {
-      throw new Error("Failed to sign in");
-    }
-    const data = await res.json();
-    console.log(data);
-    if (data) {
-      localStorage.setItem("token", data.accessToken);
-      setToken(data.accessToken);
-    }
-  };
+  const signIn = (username, password) => dispatch(signInThunk({ username, password }));
 
   const signOut = () => {
-    localStorage.removeItem("token");
-    setToken("");
+    dispatch(signOutAction());
   };
 
   return (

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -1,0 +1,64 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+
+const initialState = {
+  token: localStorage.getItem("token") || "",
+  status: "idle",
+  error: null,
+};
+
+export const signIn = createAsyncThunk(
+  "auth/signIn",
+  async ({ username, password }, { rejectWithValue }) => {
+    try {
+      const body = new URLSearchParams();
+      body.append("userName", username);
+      body.append("password", password);
+      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+      const res = await fetch(`${backend_url}/auth/signin`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "Failed to sign in");
+      }
+      const data = await res.json();
+      return data.accessToken;
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    signOut(state) {
+      state.token = "";
+      localStorage.removeItem("token");
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(signIn.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(signIn.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.token = action.payload;
+        localStorage.setItem("token", action.payload);
+      })
+      .addCase(signIn.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      });
+  },
+});
+
+export const { signOut } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/configurationDetailsSlice.js
+++ b/src/store/configurationDetailsSlice.js
@@ -1,0 +1,104 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+
+const getToken = () => localStorage.getItem("token") || "";
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+
+export const fetchConfigurationDetails = createAsyncThunk(
+  "configDetails/fetchConfigurationDetails",
+  async (id, { rejectWithValue }) => {
+    try {
+      const res = await fetch(`${backend_url}/configurations/${id}`, {
+        headers: { Authorization: `Bearer ${getToken()}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch configuration");
+      return await res.json();
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+export const fetchConfigurationItems = createAsyncThunk(
+  "configDetails/fetchConfigurationItems",
+  async (id, { rejectWithValue }) => {
+    try {
+      const res = await fetch(`${backend_url}/items?configurationId=${id}`, {
+        headers: { Authorization: `Bearer ${getToken()}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch tour items");
+      const data = await res.json();
+      return Array.isArray(data) ? data : data.items || [];
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+export const performConfigurationAction = createAsyncThunk(
+  "configDetails/performConfigurationAction",
+  async ({ id, action }, { rejectWithValue }) => {
+    try {
+      const res = await fetch(`${backend_url}/configurations/${id}/${action}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${getToken()}` },
+      });
+      if (!res.ok) throw new Error("Action failed");
+      return await res.json();
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+const configurationDetailsSlice = createSlice({
+  name: "configDetails",
+  initialState: {
+    config: null,
+    items: [],
+    status: "idle",
+    itemsStatus: "idle",
+    error: "",
+    itemsError: "",
+  },
+  reducers: {
+    updateAvailableSlots(state, action) {
+      const { itemId, availableSlots } = action.payload;
+      state.items = state.items.map((it) =>
+        it.id === itemId ? { ...it, availableSlots } : it
+      );
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchConfigurationDetails.pending, (state) => {
+        state.status = "loading";
+        state.error = "";
+      })
+      .addCase(fetchConfigurationDetails.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.config = action.payload;
+      })
+      .addCase(fetchConfigurationDetails.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      })
+      .addCase(fetchConfigurationItems.pending, (state) => {
+        state.itemsStatus = "loading";
+        state.itemsError = "";
+      })
+      .addCase(fetchConfigurationItems.fulfilled, (state, action) => {
+        state.itemsStatus = "succeeded";
+        state.items = action.payload;
+      })
+      .addCase(fetchConfigurationItems.rejected, (state, action) => {
+        state.itemsStatus = "failed";
+        state.itemsError = action.payload;
+      })
+      .addCase(performConfigurationAction.fulfilled, (state, action) => {
+        state.config = action.payload;
+      });
+  },
+});
+
+export const { updateAvailableSlots } = configurationDetailsSlice.actions;
+export default configurationDetailsSlice.reducer;

--- a/src/store/createConfigurationSlice.js
+++ b/src/store/createConfigurationSlice.js
@@ -1,0 +1,115 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+
+const getToken = () => localStorage.getItem("token") || "";
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+
+export const fetchCities = createAsyncThunk(
+  "configForm/fetchCities",
+  async (_, { rejectWithValue }) => {
+    try {
+      const res = await fetch(`${backend_url}/cities`, {
+        headers: { Authorization: `Bearer ${getToken()}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch cities");
+      return await res.json();
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+export const fetchExperiences = createAsyncThunk(
+  "configForm/fetchExperiences",
+  async ({ cityName }, { rejectWithValue }) => {
+    try {
+      const res = await fetch(
+        `${backend_url}/tours?cityName=${encodeURIComponent(cityName)}&pageSize=20&pageNumber=1`,
+        { headers: { Authorization: `Bearer ${getToken()}` } }
+      );
+      if (!res.ok) throw new Error("Failed to fetch experiences");
+      const data = await res.json();
+      return data.items || [];
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+export const fetchGuides = createAsyncThunk(
+  "configForm/fetchGuides",
+  async ({ cityId }, { rejectWithValue }) => {
+    try {
+      const res = await fetch(
+        `${backend_url}/guides?cityId=${cityId}&pageSize=20&pageNumber=1`,
+        { headers: { Authorization: `Bearer ${getToken()}` } }
+      );
+      if (!res.ok) throw new Error("Failed to fetch guides");
+      const data = await res.json();
+      return data.items || [];
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+export const createConfiguration = createAsyncThunk(
+  "configForm/createConfiguration",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await fetch(`${backend_url}/configuration`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${getToken()}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "Failed to create configuration");
+      }
+      return true;
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+const createConfigurationSlice = createSlice({
+  name: "configForm",
+  initialState: {
+    cities: [],
+    experiences: [],
+    guides: [],
+    status: "idle",
+    error: "",
+    createStatus: "idle",
+    createError: "",
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchCities.fulfilled, (state, action) => {
+        state.cities = action.payload;
+      })
+      .addCase(fetchExperiences.fulfilled, (state, action) => {
+        state.experiences = action.payload;
+      })
+      .addCase(fetchGuides.fulfilled, (state, action) => {
+        state.guides = action.payload;
+      })
+      .addCase(createConfiguration.pending, (state) => {
+        state.createStatus = "loading";
+        state.createError = "";
+      })
+      .addCase(createConfiguration.fulfilled, (state) => {
+        state.createStatus = "succeeded";
+      })
+      .addCase(createConfiguration.rejected, (state, action) => {
+        state.createStatus = "failed";
+        state.createError = action.payload;
+      });
+  },
+});
+
+export default createConfigurationSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,15 @@
 import { configureStore } from "@reduxjs/toolkit";
 import configurationsReducer from "./configurationsSlice.js";
+import authReducer from "./authSlice.js";
+import configDetailsReducer from "./configurationDetailsSlice.js";
+import createConfigReducer from "./createConfigurationSlice.js";
 
 const store = configureStore({
   reducer: {
     configurations: configurationsReducer,
+    auth: authReducer,
+    configDetails: configDetailsReducer,
+    configForm: createConfigReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- add `authSlice` for handling login tokens
- create `configurationDetailsSlice` and `createConfigurationSlice`
- wire new reducers into the store
- update AuthContext to dispatch thunk actions
- refactor configuration pages to use redux thunks

## Testing
- `npx eslint .`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685957ef7df8832785f1d371fde9e070