### PR TITLE
Fix Vercel API base URL

### DIFF
--- a/src/context/NotificationContext.jsx
+++ b/src/context/NotificationContext.jsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useRef } from "react";
 import { HubConnectionBuilder, LogLevel } from "@microsoft/signalr";
 import { useAuth } from "./AuthContext.jsx";
 
-const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
 const hubUrl = backend_url.replace(/\/api\/v1\/?$/, "") + "/hubs/notifications";
 
 const NotificationContext = createContext(undefined);

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -13,7 +13,7 @@ export const signIn = createAsyncThunk(
       const body = new URLSearchParams();
       body.append("userName", username);
       body.append("password", password);
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
       const res = await fetch(`${backend_url}/auth/signin`, {
         method: "POST",
         headers: {

--- a/src/store/configurationDetailsSlice.js
+++ b/src/store/configurationDetailsSlice.js
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 
 const getToken = () => localStorage.getItem("token") || "";
-const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
 
 export const fetchConfigurationDetails = createAsyncThunk(
   "configDetails/fetchConfigurationDetails",

--- a/src/store/configurationsSlice.js
+++ b/src/store/configurationsSlice.js
@@ -9,7 +9,7 @@ export const fetchConfigurations = createAsyncThunk(
       if (pageNumber) params.append("pageNumber", pageNumber);
       if (cityId !== undefined) params.append("cityId", cityId);
       const token = getToken();
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
       const response = await fetch(
         `${backend_url}/configurations?${params.toString()}`,
         {
@@ -33,7 +33,7 @@ export const openConfiguration = createAsyncThunk(
   async ({ id }, { rejectWithValue }) => {
     try {
       const token = getToken();
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
       const url = `${backend_url}/configurations/${id}/open`;
       const res = await fetch(url, {
         method: "POST",
@@ -54,7 +54,7 @@ export const closeConfiguration = createAsyncThunk(
   async ({ id }, { rejectWithValue }) => {
     try {
       const token = getToken();
-      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+      const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
       const url = `${backend_url}/configurations/${id}/close`;
 
       const res = await fetch(url, {

--- a/src/store/createConfigurationSlice.js
+++ b/src/store/createConfigurationSlice.js
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 
 const getToken = () => localStorage.getItem("token") || "";
-const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "/api";
 
 export const fetchCities = createAsyncThunk(
   "configForm/fetchCities",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/:path*" },
     {
       "source": "/(.*)",
       "destination": "/index.html"


### PR DESCRIPTION
## Summary
- use `/api` as default backend URL
- preserve API routes in Vercel rewrites

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68595dc4ea888327a759587dd98617bc