### PR TITLE
Improve configuration UX

### DIFF
--- a/src/components/configuration/ConfigurationList.jsx
+++ b/src/components/configuration/ConfigurationList.jsx
@@ -8,9 +8,11 @@ import {
 } from "../ui/table";
 import { PlayIcon, StopIconCircle, TrashBinIcon } from "../../icons";
 import Spinner from "../ui/spinner/Spinner";
+import Badge from "../ui/badge/Badge.jsx";
 export default function ConfigurationList({
   list,
   actionStatus,
+  highlightId,
   onOpen,
   onClose,
   onDelete,
@@ -61,14 +63,14 @@ export default function ConfigurationList({
         </TableRow>
       </TableHeader>
       <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05]">
-        {list.map((cfg) => {
+        {list.map((cfg) => { 
           const loading = actionStatus[cfg.id] === "loading";
           return (
             <TableRow
               key={cfg.id}
               className={`cursor-pointer ${
-                cfg.isRunning ? " dark:bg-brand-500/12" : ""
-              }`}
+                cfg.id === highlightId ? "bg-blue-50 dark:bg-blue-900/10" : ""
+              } ${cfg.isRunning ? " dark:bg-brand-500/12" : ""}`}
               handleClick={(event) => {
                 event.stopPropagation();
                 onItemSelection(cfg.id);
@@ -77,8 +79,11 @@ export default function ConfigurationList({
               <TableCell>{loading ? <Spinner /> : renderAction(cfg)}</TableCell>
               <TableCell>
                 <div className="leading-snug">
-                  <div className="dark:text-white font-medium truncate">
+                  <div className="dark:text-white font-medium truncate flex items-center gap-1">
                     {cfg.description}
+                    {highlightId === cfg.id && (
+                      <Badge variant="light" color="info">NEW</Badge>
+                    )}
                   </div>
                   <div
                     className={`text-theme-xs   ${

--- a/src/pages/ConfigurationPages/CreateSelfSchedulingConfiguration.jsx
+++ b/src/pages/ConfigurationPages/CreateSelfSchedulingConfiguration.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router";
 import {
   fetchCities,
   fetchExperiences,
@@ -24,6 +25,7 @@ import {
 
 export default function CreateSelfSchedulingConfiguration() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { cities, experiences, guides, createStatus, createError } =
     useSelector((state) => state.configForm);
 
@@ -40,7 +42,6 @@ export default function CreateSelfSchedulingConfiguration() {
   const [selectedExperienceIds, setSelectedExperienceIds] = useState([]);
   const [selectedGuideIds, setSelectedGuideIds] = useState([]);
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState(false);
   const minDate = new Date();
   minDate.setDate(minDate.getDate() + 1);
   minDate.setHours(0, 0, 0, 0);
@@ -136,7 +137,9 @@ export default function CreateSelfSchedulingConfiguration() {
     };
     const res = await dispatch(createConfigurationThunk(payload));
     if (createConfigurationThunk.fulfilled.match(res)) {
-      setSuccess(true);
+      const newId = res.payload && res.payload.id ? res.payload.id : undefined;
+      navigate('/self-scheduling-configurations', { state: { newId } });
+      return;
     } else if (res.payload) {
       setError(res.payload);
     } else {
@@ -153,7 +156,6 @@ export default function CreateSelfSchedulingConfiguration() {
       <PageBreadcrumb pageTitle="Add Self Scheduling Configuration" />
       {error && <p className="text-red-500 mb-3">{error}</p>}
       {createError && <p className="text-red-500 mb-3">{createError}</p>}
-      {success && <p className="text-green-500 mb-3">Configuration created</p>}
       {!cities ? (
         <Spinner />
       ) : (
@@ -166,13 +168,13 @@ export default function CreateSelfSchedulingConfiguration() {
               onChange={(val) => {
                 setCityId(val);
               }}
-              disabled={createStatus === "loading" || success}
+              disabled={createStatus === "loading"}
             />
           </div>
           <div>
             <Label htmlFor="desc">Description</Label>
             <InputField
-              disabled={createStatus === "loading" || success}
+              disabled={createStatus === "loading"}
               id="desc"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -180,7 +182,7 @@ export default function CreateSelfSchedulingConfiguration() {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <MyDateRangePicker
-              disabled={createStatus === "loading" || success}
+              disabled={createStatus === "loading"}
               id="schedulingRange"
               label="Scheduling Window"
               value={schedulingRange}
@@ -200,7 +202,7 @@ export default function CreateSelfSchedulingConfiguration() {
             />
 
             <MyDateRangePicker
-              disabled={createStatus === "loading" || success}
+              disabled={createStatus === "loading"}
               id="toursRange"
               label="Tours Period"
               value={toursRange}
@@ -221,7 +223,7 @@ export default function CreateSelfSchedulingConfiguration() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <SelectableListModal
-                disabled={createStatus === "loading" || success}
+                disabled={createStatus === "loading"}
                 title="Experiences"
                 items={experiences}
                 selected={selectedExperienceIds}
@@ -257,7 +259,7 @@ export default function CreateSelfSchedulingConfiguration() {
             </div>
             <div>
               <SelectableListModal
-                disabled={createStatus === "loading" || success}
+                disabled={createStatus === "loading"}
                 title="Guides"
                 items={guides}
                 selected={selectedGuideIds}
@@ -294,7 +296,7 @@ export default function CreateSelfSchedulingConfiguration() {
           </div>
           <div>
             <Button
-              disabled={createStatus === "loading" || success}
+              disabled={createStatus === "loading"}
               type="submit"
               className="bg-brand-500 text-white hover:bg-brand-600"
             >

--- a/src/pages/ConfigurationPages/SelfSchedulingConfigurationDetails.jsx
+++ b/src/pages/ConfigurationPages/SelfSchedulingConfigurationDetails.jsx
@@ -33,8 +33,12 @@ export default function SelfSchedulingConfigurationDetails() {
     dispatch(fetchConfigurationItems(id));
   }, [dispatch, id]);
 
-  const handleAction = (action) => {
-    dispatch(performConfigurationAction({ id, action }));
+  const handleAction = async (action) => {
+    const result = await dispatch(performConfigurationAction({ id, action }));
+    if (performConfigurationAction.fulfilled.match(result)) {
+      dispatch(fetchConfigurationDetails(id));
+      dispatch(fetchConfigurationItems(id));
+    }
   };
 
   const handleSimulation = () => {

--- a/src/pages/ConfigurationPages/SelfSchedulingConfigurations.jsx
+++ b/src/pages/ConfigurationPages/SelfSchedulingConfigurations.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import PageBreadcrumb from "../../components/common/PageBreadCrumb.jsx";
 import PageMeta from "../../components/common/PageMeta.jsx";
 import {
@@ -17,6 +17,8 @@ import ConfigurationList from "../../components/configuration/ConfigurationList.
 export default function SelfSchedulingConfigurations() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
+  const highlightId = location.state?.newId;
   const {
     isOpen: isDeleteOpen,
     openModal: openDeleteModal,
@@ -77,6 +79,7 @@ export default function SelfSchedulingConfigurations() {
             <ConfigurationList
               list={list}
               actionStatus={actionStatus}
+              highlightId={highlightId}
               onDelete={handleDeleteClick}
               onOpen={handleOpenClick}
               onClose={handleCloseClick}

--- a/src/store/createConfigurationSlice.js
+++ b/src/store/createConfigurationSlice.js
@@ -84,11 +84,15 @@ export const createConfiguration = createAsyncThunk(
         },
         body: JSON.stringify(payload),
       });
+      const text = await res.text();
       if (!res.ok) {
-        const text = await res.text();
         throw new Error(text || "Failed to create configuration");
       }
-      return true;
+      try {
+        return text ? JSON.parse(text) : true;
+      } catch (e) {
+        return true;
+      }
     } catch (err) {
       return rejectWithValue(err.message);
     }


### PR DESCRIPTION
## Summary
- refresh configuration data after open/close actions
- redirect to configuration list after creation and mark new configuration
- highlight new configuration in list with `NEW` badge
- parse create response for new configuration ID

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ca1c1af9c8327ac5c2d2b4952e0b2