### PR TITLE
Add item slice and improve item details page

### DIFF
--- a/src/pages/ConfigurationPages/SelfSchedulingItemDetails.jsx
+++ b/src/pages/ConfigurationPages/SelfSchedulingItemDetails.jsx
@@ -1,47 +1,55 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useParams } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
 import PageMeta from "../../components/common/PageMeta.jsx";
+import useGoBack from "../../hooks/useGoBack.js";
+import { ChevronLeftIcon } from "../../icons";
+import { fetchItemDetails } from "../../store/itemSlice.js";
 // import LogStream from "../../components/logviewer/LogStream.jsx";
 
 export default function SelfSchedulingItemDetails() {
   const { id } = useParams();
-  const [item, setItem] = useState(null);
-  const [status, setStatus] = useState("loading");
-  const [error, setError] = useState("");
+  const dispatch = useDispatch();
+  const goBack = useGoBack();
+  const { item, status, error } = useSelector((state) => state.items);
 
   useEffect(() => {
-    const backendUrl =
-      import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
-    fetch(`${backendUrl}/items/${id}`, {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token") || ""}` },
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error("Failed to fetch item");
-        return res.json();
-      })
-      .then((data) => {
-        setItem(data);
-        setStatus("succeeded");
-      })
-      .catch((err) => {
-        setError(err.message);
-        setStatus("failed");
-      });
-  }, [id]);
+    dispatch(fetchItemDetails(id));
+  }, [dispatch, id]);
 
   return (
     <>
-      <PageMeta title="Item Details" description="Schedulable item overview" />
+      <PageMeta title="Tour Item Details" description="Schedulable item overview" />
+      <div className="mb-6 flex items-center gap-2">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            goBack();
+          }}
+          className="text-gray-400 text-2xl flex mr-10 hover:text-gray-800"
+        >
+          <ChevronLeftIcon className="inline-block" />
+        </button>
+        <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90">
+          Tour Item Details
+        </h2>
+      </div>
       {status === "loading" && <p>Loading...</p>}
       {error && <p className="text-red-500">{error}</p>}
       {item && (
         <div className="space-y-2">
-          <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90">
+          <h3 className="text-lg font-medium text-gray-800 dark:text-white/90">
             {item.name}
-          </h2>
+          </h3>
           <p className="text-gray-500">ID: {item.id}</p>
           <p className="text-gray-500">Tour Date: {item.tourDate}</p>
           <p className="text-gray-500">Available Slots: {item.availableSlots}</p>
+          <p className="text-gray-500">
+            Reserved Slots: {item.reservedSlots ? item.reservedSlots.length : 0}
+          </p>
+          <p className="text-gray-500">
+            Confirmed Slots: {item.confirmedSlots ? item.confirmedSlots.length : 0}
+          </p>
         </div>
       )}
       {/* <div className="mt-6">

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import authReducer from "./authSlice.js";
 import configDetailsReducer from "./configurationDetailsSlice.js";
 import createConfigReducer from "./createConfigurationSlice.js";
 import notificationsReducer from "./notificationsSlice.js";
+import itemsReducer from "./itemSlice.js";
 
 const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ const store = configureStore({
     configDetails: configDetailsReducer,
     configForm: createConfigReducer,
     notifications: notificationsReducer,
+    items: itemsReducer,
   },
 });
 

--- a/src/store/itemSlice.js
+++ b/src/store/itemSlice.js
@@ -1,0 +1,53 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+
+const getToken = () => localStorage.getItem("token") || "";
+const backend_url =
+  import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+
+export const fetchItemDetails = createAsyncThunk(
+  "items/fetchItemDetails",
+  async (id, { rejectWithValue }) => {
+    try {
+      const headers = { Authorization: `Bearer ${getToken()}` };
+      const [itemRes, slotRes] = await Promise.all([
+        fetch(`${backend_url}/items/${id}`, { headers }),
+        fetch(`${backend_url}/items/slotinfo/${id}`, { headers }),
+      ]);
+      if (!itemRes.ok) throw new Error("Failed to fetch item");
+      if (!slotRes.ok) throw new Error("Failed to fetch slot info");
+      const itemData = await itemRes.json();
+      const slotData = await slotRes.json();
+      return {
+        ...itemData,
+        availableSlots: slotData.initialAvailability,
+        reservedSlots: slotData.reservedSlots,
+        confirmedSlots: slotData.confirmedSlots,
+      };
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+const itemsSlice = createSlice({
+  name: "items",
+  initialState: { item: null, status: "idle", error: "" },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchItemDetails.pending, (state) => {
+        state.status = "loading";
+        state.error = "";
+      })
+      .addCase(fetchItemDetails.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.item = action.payload;
+      })
+      .addCase(fetchItemDetails.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      });
+  },
+});
+
+export default itemsSlice.reducer;


### PR DESCRIPTION
## Summary
- add an items slice with async action to fetch item and slot info
- register the new slice in the store
- refactor item details page to use Redux and show slot information

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cb301bb60832798f20554817ddbf7