### PR TITLE
Add notifications widget

### DIFF
--- a/src/components/notifications/NotificationsWidget.jsx
+++ b/src/components/notifications/NotificationsWidget.jsx
@@ -1,33 +1,49 @@
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import ComponentCard from "../common/ComponentCard.jsx";
+import { clearNotifications } from "../../store/notificationsSlice.js";
 
 export default function NotificationsWidget() {
+  const dispatch = useDispatch();
   const notifications = useSelector((state) => state.notifications.items);
+
+  const handleClear = () => {
+    dispatch(clearNotifications());
+  };
 
   return (
     <ComponentCard title="Notifications">
       {notifications.length === 0 ? (
         <p className="text-sm text-gray-500 dark:text-gray-400">No notifications</p>
       ) : (
-        <ul className="flex flex-col max-h-96 overflow-y-auto custom-scrollbar divide-y divide-gray-100 dark:divide-gray-800">
-          {notifications.map((n, idx) => (
-            <li key={idx} className="py-2">
-              <p className="font-medium text-gray-800 dark:text-white/90">
-                {n.EventType === "ConfigurationCreatedEvent"
-                  ? "A configuration was created"
-                  : n.EventType === "ConfigurationOpenedEvent"
-                  ? "A configuration was opened"
-                  : n.EventType}
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {new Date(n.CreatedOn).toLocaleString()}
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {n.Description || "No description available."}
-              </p>
-            </li>
-          ))}
-        </ul>
+        <>
+          <div className="flex justify-end">
+            <button
+              onClick={handleClear}
+              className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+            >
+              Clear All
+            </button>
+          </div>
+          <ul className="flex flex-col max-h-96 overflow-y-auto custom-scrollbar divide-y divide-gray-100 dark:divide-gray-800">
+            {notifications.map((n, idx) => (
+              <li key={n.ConfigurationId ?? idx} className="py-2">
+                <p className="font-medium text-gray-800 dark:text-white/90">
+                  {n.EventType === "ConfigurationCreatedEvent"
+                    ? "A configuration was created"
+                    : n.EventType === "ConfigurationOpenedEvent"
+                    ? "A configuration was opened"
+                    : n.EventType}
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {new Date(n.CreatedOn).toLocaleString()}
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {n.Description || "No description available."}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
     </ComponentCard>
   );

--- a/src/components/notifications/NotificationsWidget.jsx
+++ b/src/components/notifications/NotificationsWidget.jsx
@@ -1,0 +1,34 @@
+import { useSelector } from "react-redux";
+import ComponentCard from "../common/ComponentCard.jsx";
+
+export default function NotificationsWidget() {
+  const notifications = useSelector((state) => state.notifications.items);
+
+  return (
+    <ComponentCard title="Notifications">
+      {notifications.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">No notifications</p>
+      ) : (
+        <ul className="flex flex-col max-h-96 overflow-y-auto custom-scrollbar divide-y divide-gray-100 dark:divide-gray-800">
+          {notifications.map((n, idx) => (
+            <li key={idx} className="py-2">
+              <p className="font-medium text-gray-800 dark:text-white/90">
+                {n.EventType === "ConfigurationCreatedEvent"
+                  ? "A configuration was created"
+                  : n.EventType === "ConfigurationOpenedEvent"
+                  ? "A configuration was opened"
+                  : n.EventType}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {new Date(n.CreatedOn).toLocaleString()}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {n.Description || "No description available."}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </ComponentCard>
+  );
+}

--- a/src/pages/Dashboard/Home.jsx
+++ b/src/pages/Dashboard/Home.jsx
@@ -5,6 +5,7 @@ import MonthlyTarget from "../../components/ecommerce/MonthlyTarget";
 import RecentOrders from "../../components/ecommerce/RecentOrders";
 import DemographicCard from "../../components/ecommerce/DemographicCard";
 import PageMeta from "../../components/common/PageMeta";
+import NotificationsWidget from "../../components/notifications/NotificationsWidget.jsx";
 export default function Home() {
     return (<>
       <PageMeta title="React.js Ecommerce Dashboard | TailAdmin - React.js Admin Dashboard Template" description="This is React.js Ecommerce Dashboard page for TailAdmin - React.js Tailwind CSS Admin Dashboard Template"/>
@@ -29,6 +30,10 @@ export default function Home() {
 
         <div className="col-span-12 xl:col-span-7">
           <RecentOrders />
+        </div>
+
+        <div className="col-span-12">
+          <NotificationsWidget />
         </div>
       </div>
     </>);

--- a/src/pages/Dashboard/Home.jsx
+++ b/src/pages/Dashboard/Home.jsx
@@ -5,7 +5,7 @@ import MonthlyTarget from "../../components/ecommerce/MonthlyTarget";
 import RecentOrders from "../../components/ecommerce/RecentOrders";
 import DemographicCard from "../../components/ecommerce/DemographicCard";
 import PageMeta from "../../components/common/PageMeta";
-import NotificationsWidget from "../../components/notifications/NotificationsWidget.jsx";
+import NotificationsWidget from "../../components/notifications/NotificationsWidget";
 export default function Home() {
     return (<>
       <PageMeta title="React.js Ecommerce Dashboard | TailAdmin - React.js Admin Dashboard Template" description="This is React.js Ecommerce Dashboard page for TailAdmin - React.js Tailwind CSS Admin Dashboard Template"/>


### PR DESCRIPTION
## Summary
- add `NotificationsWidget` component for viewing notifications
- include notifications widget on the Dashboard Home page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ceafd27e88327bea6abfd0c7a23f0