### PR TITLE
Add date multi-select filter

### DIFF
--- a/src/components/form/MultiSelect.jsx
+++ b/src/components/form/MultiSelect.jsx
@@ -1,6 +1,11 @@
-import { useState } from "react";
-const MultiSelect = ({ label, options, defaultSelected = [], onChange, disabled = false, }) => {
-    const [selectedOptions, setSelectedOptions] = useState(defaultSelected);
+import { useState, useEffect } from "react";
+const MultiSelect = ({ label, options, defaultSelected = [], value, onChange, disabled = false, }) => {
+    const [selectedOptions, setSelectedOptions] = useState(value ?? defaultSelected);
+    useEffect(() => {
+        if (value !== undefined) {
+            setSelectedOptions(value);
+        }
+    }, [value]);
     const [isOpen, setIsOpen] = useState(false);
     const toggleDropdown = () => {
         if (!disabled)
@@ -10,19 +15,23 @@ const MultiSelect = ({ label, options, defaultSelected = [], onChange, disabled 
         const newSelectedOptions = selectedOptions.includes(optionValue)
             ? selectedOptions.filter((value) => value !== optionValue)
             : [...selectedOptions, optionValue];
-        setSelectedOptions(newSelectedOptions);
+        if (value === undefined) {
+            setSelectedOptions(newSelectedOptions);
+        }
         onChange?.(newSelectedOptions);
     };
-    const removeOption = (value) => {
-        const newSelectedOptions = selectedOptions.filter((opt) => opt !== value);
-        setSelectedOptions(newSelectedOptions);
+    const removeOption = (val) => {
+        const newSelectedOptions = selectedOptions.filter((opt) => opt !== val);
+        if (value === undefined) {
+            setSelectedOptions(newSelectedOptions);
+        }
         onChange?.(newSelectedOptions);
     };
     const selectedValuesText = selectedOptions.map((value) => options.find((option) => option.value === value)?.text || "");
     return (<div className="w-full">
-      <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-400">
-        {label}
-      </label>
+      {label && (<label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-400">
+            {label}
+          </label>)}
 
       <div className="relative z-20 inline-block w-full">
         <div className="relative flex flex-col items-center">

--- a/src/pages/ConfigurationPages/TourItemList.jsx
+++ b/src/pages/ConfigurationPages/TourItemList.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -8,6 +8,7 @@ import {
 } from "../../components/ui/table/index.jsx";
 import ComponentCard from "../../components/common/ComponentCard.jsx";
 import Input from "../../components/form/input/InputField.jsx";
+import MultiSelect from "../../components/form/MultiSelect.jsx";
 export default function TourItemList({
   itemsStatus,
   itemsError,
@@ -15,8 +16,13 @@ export default function TourItemList({
   onItemSelection,
   highlightId,
 }) {
-  const [filterDate, setFilterDate] = useState("");
+  const uniqueDates = Array.from(new Set(items.map((it) => it.tourDate)));
+  const [selectedDates, setSelectedDates] = useState(uniqueDates);
   const [filterId, setFilterId] = useState("");
+
+  useEffect(() => {
+    setSelectedDates(uniqueDates);
+  }, [items]);
   const sortedItems = [...items].sort((a, b) => {
     const ta = new Date(a.updatedAt || a.tourDate);
     const tb = new Date(b.updatedAt || b.tourDate);
@@ -24,7 +30,7 @@ export default function TourItemList({
     return (a.name || "").localeCompare(b.name || "");
   });
   const filteredItems = sortedItems.filter((it) => {
-    const dateOk = filterDate ? it.tourDate.startsWith(filterDate) : true;
+    const dateOk = selectedDates.length > 0 ? selectedDates.includes(it.tourDate) : false;
     const idOk = filterId ? String(it.id).includes(filterId) : true;
     return dateOk && idOk;
   });
@@ -48,11 +54,21 @@ export default function TourItemList({
                     />
                   </TableCell>
                   <TableCell isHeader className="px-6 py-2">
-                    <Input
-                      type="date"
-                      value={filterDate}
-                      onChange={(e) => setFilterDate(e.target.value)}
-                    />
+                    <div className="flex items-start space-x-2">
+                      <MultiSelect
+                        label={null}
+                        options={uniqueDates.map((d) => ({ value: d, text: d }))}
+                        value={selectedDates}
+                        onChange={setSelectedDates}
+                      />
+                      <button
+                        type="button"
+                        className="text-xs text-gray-500 underline"
+                        onClick={() => setSelectedDates([])}
+                      >
+                        Clear
+                      </button>
+                    </div>
                   </TableCell>
                   <TableCell isHeader />
                   <TableCell isHeader />


### PR DESCRIPTION
## Summary
- allow MultiSelect to be controlled and optional label
- filter tour items by selectable dates with clear option

## Testing
- `npm run lint` *(fails: clearNotifications, it, data not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685eb40fa82c83278a39e49ed98754f6