### PR TITLE
Add vertical tabs component for snapshots

### DIFF
--- a/src/components/common/Ribbon.jsx
+++ b/src/components/common/Ribbon.jsx
@@ -1,0 +1,7 @@
+export default function Ribbon({ children }) {
+  return (
+    <span className="absolute -right-[23px] inline-block rounded-l-full bg-success-500 px-4 py-1.5 text-sm font-medium text-white">
+      {children}
+    </span>
+  );
+}

--- a/src/components/common/Tabs.jsx
+++ b/src/components/common/Tabs.jsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 
-export function Tabs({ tabsData }) {
+export default function Tabs({ tabsData }) {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
 
   return (
-    <div className="rounded-xl border border-gray-200 p-6 dark:border-gray-800">
+    <div className="rounded-xl  p-6">
       <nav className="-mb-px flex space-x-2 overflow-x-auto">
         {tabsData.map((tab, idx) => {
           return (
@@ -25,10 +25,6 @@ export function Tabs({ tabsData }) {
       </nav>
       {/* Show active tab content. */}
       <div className="pt-4 dark:border-gray-800">
-        <h3 className="mb-1 text-xl font-medium text-gray-800 dark:text-white/90">
-          {tabsData[activeTabIndex].label}
-        </h3>
-
         <div className="text-sm text-gray-500 dark:text-gray-400">
           {tabsData[activeTabIndex].content}
         </div>

--- a/src/components/common/VerticalTabs.jsx
+++ b/src/components/common/VerticalTabs.jsx
@@ -1,31 +1,36 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
-export function VerticalTabs({ tabsData }) {
+export default function VerticalTabs({ tabsData, addOn }) {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
 
+  useEffect(() => {
+    setActiveTabIndex(0);
+  }, []);
   return (
-    <div className="rounded-xl border border-gray-200 p-6 dark:border-gray-800">
-      <div className="flex">
-        <nav className="-mb-px flex w-48 flex-col border-r border-gray-200 dark:border-gray-800">
-          {tabsData.map((tab, idx) => (
-            <button
-              key={idx}
-              className={`border-l-2 px-2.5 py-2 text-left text-sm font-medium transition-colors duration-200 ease-in-out ${
-                idx === activeTabIndex
-                  ? "text-brand-500 dark:text-brand-400 border-brand-500 dark:border-brand-400"
-                  : "text-gray-500 border-transparent hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-              }`}
-              onClick={() => setActiveTabIndex(idx)}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-        <div className="flex-1 pl-6">
-          <h3 className="mb-1 text-xl font-medium text-gray-800 dark:text-white/90">
-            {tabsData[activeTabIndex].label}
-          </h3>
-          <div className="text-sm text-gray-500 dark:text-gray-400">
+    <div className="rounded-xl">
+      <div className="flex flex-col gap-6 sm:flex-row sm:gap-8">
+        <div className="overflow-x-auto pb-2 sm:w-[200px]">
+          <nav className="flex w-full flex-row sm:flex-col sm:space-y-2">
+            {addOn && (
+              <div className="pb-6 mb-6 border-b border-gray-800">{addOn}</div>
+            )}
+            {tabsData.map((tab, idx) => (
+              <button
+                key={idx}
+                className={`inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-200 ease-in-out sm:p-3 ${
+                  idx === activeTabIndex
+                    ? " text-brand-500 dark:bg-brand-400/20 dark:text-brand-400 bg-brand-50"
+                    : "py-2.5  bg-transparent text-gray-500 border-transparent hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                }`}
+                onClick={() => setActiveTabIndex(idx)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </nav>
+        </div>
+        <div className="flex-1">
+          <div className="h-full w-full text-sm text-gray-500 dark:text-gray-400">
             {tabsData[activeTabIndex].content}
           </div>
         </div>

--- a/src/components/common/VerticalTabs.jsx
+++ b/src/components/common/VerticalTabs.jsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+export function VerticalTabs({ tabsData }) {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  return (
+    <div className="rounded-xl border border-gray-200 p-6 dark:border-gray-800">
+      <div className="flex">
+        <nav className="-mb-px flex w-48 flex-col border-r border-gray-200 dark:border-gray-800">
+          {tabsData.map((tab, idx) => (
+            <button
+              key={idx}
+              className={`border-l-2 px-2.5 py-2 text-left text-sm font-medium transition-colors duration-200 ease-in-out ${
+                idx === activeTabIndex
+                  ? "text-brand-500 dark:text-brand-400 border-brand-500 dark:border-brand-400"
+                  : "text-gray-500 border-transparent hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              }`}
+              onClick={() => setActiveTabIndex(idx)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+        <div className="flex-1 pl-6">
+          <h3 className="mb-1 text-xl font-medium text-gray-800 dark:text-white/90">
+            {tabsData[activeTabIndex].label}
+          </h3>
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            {tabsData[activeTabIndex].content}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/selfscheduling/SelfSchedulingInfoCard.jsx
+++ b/src/components/selfscheduling/SelfSchedulingInfoCard.jsx
@@ -27,7 +27,7 @@ export default function SelfSchedulingInfoCard({
             <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
               Id
             </p>
-            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+            <p className="text-xs font-medium text-gray-800 dark:text-white/90">
               {selfscheduling.selfSchedulingId}
             </p>
           </div>
@@ -46,7 +46,10 @@ export default function SelfSchedulingInfoCard({
               Experiences Count
             </p>
             <p className="text-sm font-medium text-gray-800 dark:text-white/90">
-              {selfscheduling.configuration.experienceIds?.length || 0}
+              <Badge variant="solid" size="sm">
+                {selfscheduling.configuration.subject.experienceIds?.length ||
+                  0}
+              </Badge>
             </p>
           </div>
 
@@ -67,6 +70,7 @@ export default function SelfSchedulingInfoCard({
               <div>
                 <Badge
                   variant="light"
+                  size="sm"
                   color={selfscheduling.isRunning ? "success" : "warning"}
                 >
                   {selfscheduling.isRunning ? "Running" : "Pending"}
@@ -105,7 +109,9 @@ export default function SelfSchedulingInfoCard({
               Guides Count
             </p>
             <p className="text-sm font-medium text-gray-800 dark:text-white/90">
-              {selfscheduling.configuration.guideIds?.length || 0}
+              <Badge variant="solid" size="sm">
+                {selfscheduling.configuration.audience.guideIds?.length || 0}
+              </Badge>
             </p>
           </div>
         </div>

--- a/src/components/selfscheduling/Snapshot.jsx
+++ b/src/components/selfscheduling/Snapshot.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchSnapshotDetails } from "../../store/selfschedulingDetailsSlice.js";
+import SnapshotOverview from "./SnapshotOverview";
+import Spinner from "../ui/spinner/Spinner.jsx";
+import Tabs from "../common/Tabs.jsx";
+export default function Snapshot({ snapshotId, label, isActive }) {
+  const [tabsData, setTabsData] = useState([
+    {
+      label: "Calendar",
+      content: <span>Calendar</span>,
+    },
+  ]);
+  const dispatch = useDispatch();
+  const { snapshotsDetails } = useSelector(
+    (state) => state.selfschedulingsDetails
+  );
+  useEffect(() => {
+    dispatch(fetchSnapshotDetails(snapshotId));
+  }, [snapshotId]);
+
+  useEffect(() => {
+    if (snapshotsDetails[snapshotId] && snapshotsDetails[snapshotId].loaded) {
+      console.log(snapshotsDetails[snapshotId].data);
+      const tb = [
+        {
+          label: "Calendar",
+          content: <span>calendar</span>,
+        },
+      ];
+      setTabsData(tb);
+    }
+  }, [snapshotsDetails]);
+
+  return (
+    <>
+      {!snapshotsDetails[snapshotId] ||
+        (snapshotsDetails[snapshotId].loading && <Spinner fullscreen />)}
+      <>
+        {snapshotsDetails[snapshotId] && snapshotsDetails[snapshotId].data && (
+          <>
+            
+            <SnapshotOverview
+              isActive={isActive}
+              label={label}
+              snapshot={snapshotsDetails[snapshotId].data}
+            ></SnapshotOverview>
+
+            <div className="mt-6">
+              <Tabs tabsData={tabsData}></Tabs>
+            </div>
+          </>
+        )}
+      </>
+    </>
+  );
+}

--- a/src/components/selfscheduling/SnapshotList.jsx
+++ b/src/components/selfscheduling/SnapshotList.jsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from "react";
+import Button from "../ui/button/Button.jsx";
+import VerticalTabs from "../common/VerticalTabs.jsx"; 
+import { CheckCircleIcon, PlusIcon } from "../../icons";
+import Snapshot from "./Snapshot.jsx";
+export default function SnapshotList({
+  snapshots,
+  activeSnapshotId,
+  onAddSnapshot,
+  canAddSnapshot,
+}) {
+  const [tabsData, setTabsData] = useState(null);
+  useEffect(() => {
+    if (!snapshots?.length) return;
+
+    const active = snapshots.find((s) => s.snapshotId === activeSnapshotId);
+    const others = snapshots.filter((s) => s.snapshotId !== activeSnapshotId);
+    const ordered = active ? [active, ...others] : snapshots;
+
+    const tabs = ordered.map((s) => {
+      const isActive = s.snapshotId === activeSnapshotId;
+      return {
+        isActive,
+        label: (
+          <div className="flex flex-row w-full justify-between items-center">
+            <div className="flex-auto text-left">{s.snapshotDate}</div>
+            {isActive && (
+              <div className="text-right text-lg">
+                <CheckCircleIcon className="success text-md" />
+              </div>
+            )}
+          </div>
+        ),
+        content: (
+          <Snapshot
+            isActive={isActive}
+            snapshotId={s.snapshotId}
+            label={s.snapshotDate}
+          />
+        ),
+      };
+    });
+
+    setTabsData(tabs);
+  }, [snapshots, activeSnapshotId]);
+
+  const addOn = (
+    <div className="border-b dark:border-gray-800">
+      <Button
+        size="sm"
+        variant="outline"
+        className="w-full"
+        onClick={() => onAddSnapshot}
+        disabled={!canAddSnapshot}
+        startIcon={<PlusIcon/>}
+      >
+        Take a snapshot now
+      </Button>
+    </div>
+  );
+  return (
+    <>
+      {tabsData && (
+        <VerticalTabs tabsData={tabsData} addOn={addOn}></VerticalTabs>
+      )}
+    </>
+  );
+}

--- a/src/components/selfscheduling/SnapshotOverview.jsx
+++ b/src/components/selfscheduling/SnapshotOverview.jsx
@@ -1,0 +1,81 @@
+import ComponentCard from "../common/ComponentCard";
+import Ribbon from "../common/Ribbon";
+import Button from "../ui/button/Button";
+import Badge from "../ui/badge/Badge";
+import { CheckCircleIcon } from "../../icons";
+export default function SnapshotOverview({ snapshot, label, isActive }) {
+  const title = (
+    <div className="flex relative items-center">
+      <div className="flex-1 h-[32px]">{label}</div>
+      {isActive ? (
+        <Ribbon>active snapshot</Ribbon>
+      ) : (
+        <Button size="xs" variant="outline" endIcon={<CheckCircleIcon />}>
+          Activate
+        </Button>
+      )}
+    </div>
+  );
+  return (
+    <ComponentCard
+      title={title}
+      className={`${
+        isActive ? "border border-green-500!" : "border-transparent!"
+      }`}
+    >
+      <>
+        <div className="flex w-full text-right"></div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-7 2xl:gap-x-32">
+          <div>
+            <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
+              ID
+            </p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+              {snapshot.snapshotId}
+            </p>
+          </div>
+          <div>
+            <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
+              Created At
+            </p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+              {snapshot.selfSchedulingId}
+            </p>
+          </div>
+          <div>
+            <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
+              Snapshot Date
+            </p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+              {snapshot.snapshotDate}
+            </p>
+          </div>
+          <div>
+            <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
+              City ID
+            </p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+              {snapshot.cityId}
+            </p>
+          </div>
+          <div>
+            <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
+              Total Tours
+            </p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+              <Badge variant="solid" size="sm">{snapshot.tours.length}</Badge>
+            </p>
+          </div>
+          <div>
+            <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
+              Tours Period
+            </p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white/90">
+              {snapshot.toursPeriod.start} to {snapshot.toursPeriod.end}
+            </p>
+          </div>
+        </div>
+      </>
+    </ComponentCard>
+  );
+}

--- a/src/components/selfscheduling/Snapshots.jsx
+++ b/src/components/selfscheduling/Snapshots.jsx
@@ -1,54 +1,41 @@
-import { useState, useEffect } from "react";
-import ComponentCard from "../common/ComponentCard";
-import { Tabs } from "../common/Tabs";
-import Button from "../ui/button/Button.jsx";
+ 
+import ComponentCard from "../common/ComponentCard"; 
 import Spinner from "../ui/spinner/Spinner.jsx";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { createSnapshot } from "../../store/selfschedulingDetailsSlice.js";
 
-export default function Snapshots({ selfschedulingId }) {
+import SnapshotList from "./SnapshotList.jsx";
+export default function Snapshots({
+  snapshots,
+  activeSnapshotId,
+  snapshotStatus,
+  selfschedulingId,
+}) {
   const dispatch = useDispatch();
-  const { snapshotStatus, snapshots } = useSelector(
-    (state) => state.selfschedulingsDetails
-  );
+
   const handleSnapshot = () => {
     if (!selfschedulingId) return;
     dispatch(createSnapshot(selfschedulingId));
-  };
-  const [tabsData, setTabsData] = useState();
-
-  useEffect(() => {
-    if (snapshots && snapshots.length > 0) {
-      const tabs = snapshots.map((s) => ({
-        label: s.snapshotDate,
-        content: (
-          <div>
-            <div>{s.label}</div>
-            <div>{s.snapshotId}</div>
-          </div>
-        ),
-      }));
-      setTabsData(tabs);
-    }
-  }, [snapshots]);
+  }; 
   return (
     <ComponentCard
       title={
         <div className="flex items-center">
-          <div className="flex flex-auto">Snapshots</div>
+          <div className="flex flex-auto">Forecasting and Tours Snapshots</div>
           <div>
-            <Button
-              size="sm"
-              onClick={handleSnapshot}
-              disabled={snapshotStatus === "loading"}
-            >
-              {snapshotStatus === "loading" ? <Spinner /> : "Take snapshot"}
-            </Button>
+            {snapshotStatus === "loading" ? <Spinner fullscreen /> : <></>}
           </div>
         </div>
       }
     >
-      {tabsData && <Tabs tabsData={tabsData}></Tabs>}
+      {snapshots && (
+        <SnapshotList
+          snapshots={snapshots}
+          activeSnapshotId={activeSnapshotId}
+          onAddSnapshot={handleSnapshot}
+          canAddSnapshot={snapshotStatus !== "loading"}
+        />
+      )}
     </ComponentCard>
   );
 }

--- a/src/components/snapshots/VerticalSnapshots.jsx
+++ b/src/components/snapshots/VerticalSnapshots.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import ComponentCard from "../common/ComponentCard";
+import { VerticalTabs } from "../common/VerticalTabs";
+
+export default function VerticalSnapshots({ snapshots = [] }) {
+  const [tabsData, setTabsData] = useState([]);
+
+  useEffect(() => {
+    if (snapshots && snapshots.length > 0) {
+      const tabs = snapshots.map((s) => ({
+        label: s.label,
+        content: (
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            Placeholder content
+          </div>
+        ),
+      }));
+      setTabsData(tabs);
+    }
+  }, [snapshots]);
+
+  if (!tabsData || tabsData.length === 0) {
+    return (
+      <ComponentCard title="Snapshots">
+        <p className="text-sm text-gray-500 dark:text-gray-400">No snapshots</p>
+      </ComponentCard>
+    );
+  }
+
+  return (
+    <ComponentCard title="Snapshots">
+      <VerticalTabs tabsData={tabsData} />
+    </ComponentCard>
+  );
+}

--- a/src/components/ui/button/Button.jsx
+++ b/src/components/ui/button/Button.jsx
@@ -3,7 +3,7 @@ const Button = ({ children, size = "md", variant = "primary", startIcon, endIcon
     const sizeClasses = {
         sm: "px-4 py-3 text-sm",
         md: "px-5 py-3.5 text-sm",
-        xs: "px-3 py-2.5 text-xs"
+        xs: "px-3 py-1.5 text-xs"
     };
     // Variant Classes
     const variantClasses = {

--- a/src/components/ui/spinner/Spinner.jsx
+++ b/src/components/ui/spinner/Spinner.jsx
@@ -12,7 +12,7 @@ const Spinner = ({ description = "", fullscreen = false }) => {
     </div>
   );
   const fullscreenSpinner = (
-    <div className=" z-999999 flex h-full w-full items-center justify-center bg-white dark:bg-black">
+    <div className="z-999999 flex h-full w-full items-center justify-center">
       {spinner}
     </div>
   );

--- a/src/pages/SelfSchedulingPages/SelfSchedulingDetailsPage.jsx
+++ b/src/pages/SelfSchedulingPages/SelfSchedulingDetailsPage.jsx
@@ -28,9 +28,7 @@ export default function SelfSchedulingDetailsPage() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const { isSimulationRunning } = useSelector(
-    (state) => state.selfschedulings
-  );
+  const { isSimulationRunning } = useSelector((state) => state.selfschedulings);
   const {
     selfscheduling,
     items,
@@ -44,6 +42,9 @@ export default function SelfSchedulingDetailsPage() {
 
   const [actionLoading, setActionLoading] = useState(false);
   const [highlightId, setHighlightId] = useState(null);
+  const { snapshotStatus, snapshots } = useSelector(
+    (state) => state.selfschedulingsDetails
+  );
   useEffect(() => {
     dispatch(fetchSelfSchedulingDetails(id));
     dispatch(fetchTourItems(id));
@@ -169,7 +170,14 @@ export default function SelfSchedulingDetailsPage() {
         )
       )}
       <div className="mt-6">
-        <Snapshots snapshots={[]} selfschedulingId={id} />
+        {selfscheduling && snapshots && (
+          <Snapshots
+            activeSnapshotId={selfscheduling.activeSnapshotId}
+            snapshotStatus={snapshotStatus}
+            snapshots={snapshots}
+            selfschedulingId={id}
+          />
+        )}
       </div>
       <div className="grid grid-cols-12 gap-6 mt-6">
         <div className="col-span-8">


### PR DESCRIPTION
## Summary
- add `VerticalTabs` component for vertical orientation
- add `VerticalSnapshots` wrapper component to display snapshots with vertical tabs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686574970164832784e61833de9b56e0