### PR TITLE
Add forecast visualization table

### DIFF
--- a/src/components/common/Tabs.jsx
+++ b/src/components/common/Tabs.jsx
@@ -4,7 +4,7 @@ export default function Tabs({ tabsData }) {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
 
   return (
-    <div className="rounded-xl  p-6">
+    <div className="rounded-xl">
       <nav className="-mb-px flex space-x-2 overflow-x-auto">
         {tabsData.map((tab, idx) => {
           return (

--- a/src/components/selfscheduling/ForecastTable.jsx
+++ b/src/components/selfscheduling/ForecastTable.jsx
@@ -14,6 +14,7 @@ export default function ForecastTable({ snapshot }) {
         <Table>
           <TableHeader className="border-b border-gray-100 dark:border-white/[0.05]">
             <TableRow>
+              <TableCellHeader>Experience ID</TableCellHeader>
               <TableCellHeader>Option ID</TableCellHeader>
               <TableCellHeader>Tour Date</TableCellHeader>
               <TableCellHeader>Group Size</TableCellHeader>
@@ -24,9 +25,12 @@ export default function ForecastTable({ snapshot }) {
           <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05] text-sm">
             {forecasts.map((f) => (
               <TableRow key={`${f.optionId}-${f.tourDate}`}>
+                <TableCell className="px-5 py-2">{f.experienceId}</TableCell>
                 <TableCell className="px-5 py-2">{f.optionId}</TableCell>
                 <TableCell className="px-5 py-2">{f.tourDate}</TableCell>
-                <TableCell className="px-5 py-2">{sizeMap[f.optionId] ?? "-"}</TableCell>
+                <TableCell className="px-5 py-2">
+                  {sizeMap[f.optionId] ?? "-"}
+                </TableCell>
                 <TableCell className="px-5 py-2">{f.fulfillment}</TableCell>
                 <TableCell className="px-5 py-2">{f.demand}</TableCell>
               </TableRow>

--- a/src/components/selfscheduling/ForecastTable.jsx
+++ b/src/components/selfscheduling/ForecastTable.jsx
@@ -1,0 +1,39 @@
+import { Table, TableHeader, TableBody, TableRow, TableCell, TableCellHeader } from "../ui/table/index.jsx";
+
+export default function ForecastTable({ snapshot }) {
+  if (!snapshot) return null;
+  const { forecasts = [], groupSizes = [] } = snapshot;
+  const sizeMap = {};
+  groupSizes.forEach((g) => {
+    sizeMap[g.optionId] = g.groupSize;
+  });
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
+      <div className="max-w-full overflow-x-auto">
+        <Table>
+          <TableHeader className="border-b border-gray-100 dark:border-white/[0.05]">
+            <TableRow>
+              <TableCellHeader>Option ID</TableCellHeader>
+              <TableCellHeader>Tour Date</TableCellHeader>
+              <TableCellHeader>Group Size</TableCellHeader>
+              <TableCellHeader>Fulfillment</TableCellHeader>
+              <TableCellHeader>Demand</TableCellHeader>
+            </TableRow>
+          </TableHeader>
+          <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05] text-sm">
+            {forecasts.map((f) => (
+              <TableRow key={`${f.optionId}-${f.tourDate}`}>
+                <TableCell className="px-5 py-2">{f.optionId}</TableCell>
+                <TableCell className="px-5 py-2">{f.tourDate}</TableCell>
+                <TableCell className="px-5 py-2">{sizeMap[f.optionId] ?? "-"}</TableCell>
+                <TableCell className="px-5 py-2">{f.fulfillment}</TableCell>
+                <TableCell className="px-5 py-2">{f.demand}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/selfscheduling/Snapshot.jsx
+++ b/src/components/selfscheduling/Snapshot.jsx
@@ -4,6 +4,7 @@ import { fetchSnapshotDetails } from "../../store/selfschedulingDetailsSlice.js"
 import SnapshotOverview from "./SnapshotOverview";
 import Spinner from "../ui/spinner/Spinner.jsx";
 import Tabs from "../common/Tabs.jsx";
+import ForecastTable from "./ForecastTable.jsx";
 export default function Snapshot({ snapshotId, label, isActive }) {
   const [tabsData, setTabsData] = useState([
     {
@@ -21,16 +22,20 @@ export default function Snapshot({ snapshotId, label, isActive }) {
 
   useEffect(() => {
     if (snapshotsDetails[snapshotId] && snapshotsDetails[snapshotId].loaded) {
-      console.log(snapshotsDetails[snapshotId].data);
+      const data = snapshotsDetails[snapshotId].data;
       const tb = [
         {
           label: "Calendar",
           content: <span>calendar</span>,
         },
+        {
+          label: "Forecast",
+          content: <ForecastTable snapshot={data} />,
+        },
       ];
       setTabsData(tb);
     }
-  }, [snapshotsDetails]);
+  }, [snapshotsDetails, snapshotId]);
 
   return (
     <>

--- a/src/components/selfscheduling/Snapshot.jsx
+++ b/src/components/selfscheduling/Snapshot.jsx
@@ -25,10 +25,6 @@ export default function Snapshot({ snapshotId, label, isActive }) {
       const data = snapshotsDetails[snapshotId].data;
       const tb = [
         {
-          label: "Calendar",
-          content: <span>calendar</span>,
-        },
-        {
           label: "Forecast",
           content: <ForecastTable snapshot={data} />,
         },
@@ -44,7 +40,6 @@ export default function Snapshot({ snapshotId, label, isActive }) {
       <>
         {snapshotsDetails[snapshotId] && snapshotsDetails[snapshotId].data && (
           <>
-            
             <SnapshotOverview
               isActive={isActive}
               label={label}

--- a/src/components/selfscheduling/SnapshotOverview.jsx
+++ b/src/components/selfscheduling/SnapshotOverview.jsx
@@ -24,7 +24,6 @@ export default function SnapshotOverview({ snapshot, label, isActive }) {
       }`}
     >
       <>
-        <div className="flex w-full text-right"></div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-7 2xl:gap-x-32">
           <div>
             <p className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">
@@ -63,7 +62,9 @@ export default function SnapshotOverview({ snapshot, label, isActive }) {
               Total Tours
             </p>
             <p className="text-sm font-medium text-gray-800 dark:text-white/90">
-              <Badge variant="solid" size="sm">{snapshot.tours.length}</Badge>
+              <Badge variant="solid" size="sm">
+                {snapshot.tours.length}
+              </Badge>
             </p>
           </div>
           <div>

--- a/src/components/ui/table/index.jsx
+++ b/src/components/ui/table/index.jsx
@@ -21,7 +21,7 @@ const TableRow = ({ children, className, handleClick }) => {
 // TableCell Component
 const TableCell = ({ children, isHeader = false, className, ...props }) => {
   const CellTag = isHeader ? "th" : "td";
-  const cn = className || "px-6 py-4 whitespace-nowrap";
+  const cn = className || "px-6 py-4 whitespace-nowrap text-theme-sm";
   return (
     <CellTag className={cn} {...props}>
       {children}
@@ -33,7 +33,7 @@ const TableCellHeader = ({ children, className }) => {
   return (
     <TableCell isHeader className={cn}>
       <div className="flex items-center">
-        <p className="font-medium text-gray-500 text-theme-xs dark:text-gray-400">
+        <p className="text-theme-xs font-medium text-gray-700 dark:text-gray-400">
           {children}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- display forecasting data from snapshots in a new table
- add `ForecastTable` component
- show Forecast tab in Snapshot view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865ec94afb48327af84bc20968eb5eb