### PR TITLE
Refresh snapshot list after creating snapshot

### DIFF
--- a/src/components/selfscheduling/EmptySnapshot.jsx
+++ b/src/components/selfscheduling/EmptySnapshot.jsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import InputField from "../../components/form/input/InputField.jsx";
+import Form from "../../components/form/Form.jsx";
+import Button from "../ui/button/Button.jsx";
+import { PlusIcon } from "../../icons";
+import Spinner from "../ui/spinner/Spinner.jsx";
+export default function EmptySnapshot({ loading, onAddSnapshot }) {
+  const [snapshotLabel, setSnapshotLabel] = useState(
+    "Generated from Dashboard"
+  );
+  return (
+    <div className="mx-auto w-full max-w-[560px] text-center">
+      <div className="flex flex-col h-full justify-between border border-gray-200 dark:border-gray-800 max-h-full rounded-2xl bg-white p-6 text-center dark:bg-white/[0.03]">
+        <div className="mx-auto flex mb-6">
+          <h3 className="mb-3 font-bold text-gray-800 text-title-md dark:text-white/90 xl:text-title-l">
+            No Snapshot Taken
+          </h3>
+        </div>
+        <div className="flex  ">
+          <p className="text-base text-gray-500 mb-9 text-center dark:text-gray-400 w-full h-full">
+            Take a snapshot of Forecsting data and Tours included on this
+            SelfScheduling.
+          </p>
+        </div>
+        <Form onSubmit={(e) => e.preventDefault()}>
+          <div className="flex flex-col gap-2 sm:flex-row sm:gap-3">
+            <div className="w-full sm:w-[320px]">
+              <InputField
+                name="snapshotLabel"
+                placeholder="Snapshot Label"
+                value={snapshotLabel}
+                onChange={(e) => setSnapshotLabel(e.target.value)}
+                className="w-full px-4 py-3 text-sm text-gray-800 bg-transparent border border-gray-300 rounded-lg h-11 shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:shadow-focus-ring focus:outline-hidden dark:border-gray-700 dark:bg-gray-900 dark:text-white/90 dark:placeholder:text-gray-400 dark:focus:border-brand-300"
+              />
+            </div>
+            {onAddSnapshot && (
+              <Button
+                size="custom"
+                className="flex sm:w-[190px] items-center justify-center px-4 py-3 text-sm font-medium"
+                onClick={() => onAddSnapshot(snapshotLabel)}
+                disabled={loading}
+                startIcon={loading ? <Spinner size="xs" /> : <PlusIcon />}
+              >
+                Take a snapshot now
+              </Button>
+            )}
+          </div>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/selfscheduling/Snapshots.jsx
+++ b/src/components/selfscheduling/Snapshots.jsx
@@ -1,7 +1,10 @@
 import ComponentCard from "../common/ComponentCard";
 import Spinner from "../ui/spinner/Spinner.jsx";
 import { useDispatch } from "react-redux";
-import { createSnapshot } from "../../store/selfschedulingDetailsSlice.js";
+import {
+  createSnapshot,
+  fetchSelfSchedulingDetails,
+} from "../../store/selfschedulingDetailsSlice.js";
 
 import SnapshotList from "./SnapshotList.jsx";
 export default function Snapshots({
@@ -12,9 +15,14 @@ export default function Snapshots({
 }) {
   const dispatch = useDispatch();
 
-  const handleSnapshot = (label) => {
+  const handleSnapshot = async (label) => {
     if (!selfSchedulingId) return;
-    dispatch(createSnapshot({ selfSchedulingId, label }));
+    const result = await dispatch(
+      createSnapshot({ selfSchedulingId, label })
+    );
+    if (createSnapshot.fulfilled.match(result)) {
+      dispatch(fetchSelfSchedulingDetails(selfSchedulingId));
+    }
   };
   return (
     <ComponentCard


### PR DESCRIPTION
## Summary
- refresh snapshots list by reloading details from the backend after creating a snapshot

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866054875d8832781ae7e224bcd0ed3