### PR TITLE
Fix snapshots list scroll behavior

### DIFF
--- a/src/components/common/VerticalTabs.jsx
+++ b/src/components/common/VerticalTabs.jsx
@@ -1,15 +1,26 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 export default function VerticalTabs({ tabsData, addOn }) {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const contentRef = useRef(null);
+  const [contentHeight, setContentHeight] = useState(null);
 
   useEffect(() => {
     setActiveTabIndex(0);
   }, []);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setContentHeight(contentRef.current.clientHeight);
+    }
+  }, [activeTabIndex, tabsData]);
   return (
     <div className="rounded-xl">
-      <div className="flex flex-col gap-6 sm:flex-row sm:gap-6">
-        <div className="overflow-x-auto pb-2 sm:w-[300px] rounded-xl p-6 dark:bg-white/[0.03] ">
+      <div className="flex flex-col gap-6 sm:flex-row sm:gap-6 items-start">
+        <div
+          className="pb-2 sm:w-[300px] rounded-xl p-6 dark:bg-white/[0.03] overflow-y-auto"
+          style={contentHeight ? { maxHeight: contentHeight } : undefined}
+        >
           <nav className="flex w-full flex-row sm:flex-col sm:space-y-2">
             {addOn && (
               <div className="pb-6 mb-6 border-b border-gray-800">{addOn}</div>
@@ -29,7 +40,7 @@ export default function VerticalTabs({ tabsData, addOn }) {
             ))}
           </nav>
         </div>
-        <div className="flex-1">
+        <div ref={contentRef} className="flex-1">
           <div className="h-full w-full text-sm text-gray-500 dark:text-gray-400">
             {tabsData[activeTabIndex].content}
           </div>

--- a/src/components/snapshots/VerticalSnapshots.jsx
+++ b/src/components/snapshots/VerticalSnapshots.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import ComponentCard from "../common/ComponentCard";
-import { VerticalTabs } from "../common/VerticalTabs";
+import VerticalTabs from "../common/VerticalTabs.jsx";
 
 export default function VerticalSnapshots({ snapshots = [] }) {
   const [tabsData, setTabsData] = useState([]);


### PR DESCRIPTION
## Summary
- ensure vertical tab list doesn't exceed the height of the current tab content
- fix import of `VerticalTabs` in `VerticalSnapshots`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686606af86d4832780185ed91101b341