### PR TITLE
Add snapshot activation animation

### DIFF
--- a/src/components/selfscheduling/SnapshotList.jsx
+++ b/src/components/selfscheduling/SnapshotList.jsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Button from "../ui/button/Button.jsx";
-import VerticalTabs from "../common/VerticalTabs.jsx";
+// We'll implement our own simple vertical tabs to allow animations
 import { CheckCircleIcon, PlusIcon } from "../../icons";
 import Snapshot from "./Snapshot.jsx";
 import Spinner from "../ui/spinner/Spinner.jsx";
@@ -9,17 +9,41 @@ import Label from "../../components/form/Label.jsx";
 export default function SnapshotList({
   snapshots,
   activeSnapshotId,
+  previousActiveId,
   onAddSnapshot,
   canAddSnapshot,
   loading,
   onActivateSnapshot,
 }) {
   const [tabsData, setTabsData] = useState(null);
+  const [highlightId, setHighlightId] = useState(null);
+  const [slideInfo, setSlideInfo] = useState({ id: null, distance: 0 });
+  const itemRefs = useRef({});
+  const prevSnapshotsRef = useRef([]);
+  const getItemRef = (id) => (el) => {
+    if (el) itemRefs.current[id] = el;
+  };
   const [snapshotLabel, setSnapshotLabel] = useState(
     "Generated from Dashboard"
   );
+
+  // compute animation and highlight when snapshots or active id change
   useEffect(() => {
-    if (!snapshots?.length) return;
+    if (prevSnapshotsRef.current.length && activeSnapshotId) {
+      const prevIndex = prevSnapshotsRef.current.findIndex(
+        (s) => s.snapshotId === activeSnapshotId
+      );
+      if (prevIndex > 0) {
+        const itemHeight =
+          itemRefs.current[activeSnapshotId]?.offsetHeight || 60;
+        setSlideInfo({ id: activeSnapshotId, distance: prevIndex * itemHeight });
+      } else {
+        setSlideInfo({ id: null, distance: 0 });
+      }
+    }
+    if (previousActiveId) {
+      setHighlightId(previousActiveId);
+    }
 
     const active = snapshots.find((s) => s.snapshotId === activeSnapshotId);
     const others = snapshots.filter((s) => s.snapshotId !== activeSnapshotId);
@@ -27,8 +51,16 @@ export default function SnapshotList({
 
     const tabs = ordered.map((s) => {
       const isActive = s.snapshotId === activeSnapshotId;
+      const isPrev = s.snapshotId === highlightId;
+      const slideStyle =
+        isActive && slideInfo.id === s.snapshotId
+          ? { "--slide-distance": `${slideInfo.distance}px` }
+          : {};
       return {
+        key: s.snapshotId,
         isActive,
+        isPrev,
+        slideStyle,
         label: (
           <div className="flex flex-row w-full justify-between items-center">
             <div className="flex-auto text-left">
@@ -55,7 +87,12 @@ export default function SnapshotList({
     });
 
     setTabsData(tabs);
-  }, [snapshots, activeSnapshotId, loading]);
+    prevSnapshotsRef.current = snapshots;
+    if (previousActiveId) {
+      const t = setTimeout(() => setHighlightId(null), 2000);
+      return () => clearTimeout(t);
+    }
+  }, [snapshots, activeSnapshotId, loading, previousActiveId]);
 
   const addOn = (
     <>
@@ -87,10 +124,44 @@ export default function SnapshotList({
       </div>
     </>
   );
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveTabIndex(0);
+  }, [tabsData]);
+
   return (
     <>
       {tabsData && (
-        <VerticalTabs tabsData={tabsData} addOn={addOn}></VerticalTabs>
+        <div className="flex flex-col gap-6 sm:flex-row sm:gap-8 rounded-xl">
+          <div className="sm:w-[300px] rounded-xl p-6 dark:bg-white/[0.03]">
+            <div className="pb-6 mb-6 border-b border-gray-700">{addOn}</div>
+            <nav className="flex flex-auto sm:flex-col sm:space-y-2 overflow-y-auto">
+              {tabsData.map((tab, idx) => (
+                <button
+                  key={tab.key}
+                  ref={getItemRef(tab.key)}
+                  style={tab.slideStyle}
+                  className={`inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-all duration-300 ease-in-out sm:p-3 ${
+                    idx === activeTabIndex
+                      ? " text-brand-500 dark:bg-brand-400/20 dark:text-brand-400 bg-brand-50"
+                      : "py-2.5  bg-transparent text-gray-500 border-transparent hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                  } ${tab.isPrev ? "bg-gray-100 dark:bg-gray-800" : ""} ${
+                    tab.isActive && slideInfo.id === tab.key ? "move-top" : ""
+                  }`}
+                  onClick={() => setActiveTabIndex(idx)}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+          </div>
+          <div className="flex-1">
+            <div className="h-full w-full text-sm text-gray-500 dark:text-gray-400">
+              {tabsData[activeTabIndex].content}
+            </div>
+          </div>
+        </div>
       )}
     </>
   );

--- a/src/components/selfscheduling/Snapshots.jsx
+++ b/src/components/selfscheduling/Snapshots.jsx
@@ -1,5 +1,6 @@
 import ComponentCard from "../common/ComponentCard";
 import { useDispatch } from "react-redux";
+import { useState } from "react";
 import {
   activateSnapshot,
   createSnapshot,
@@ -14,6 +15,7 @@ export default function Snapshots({
   selfSchedulingId,
 }) {
   const dispatch = useDispatch();
+  const [prevActiveId, setPrevActiveId] = useState(null);
 
   const handleAddSnapshot = async (label) => {
     if (!selfSchedulingId) return;
@@ -24,6 +26,7 @@ export default function Snapshots({
   };
   const handleActivateSnapshot = async (snapshotId) => {
     if (!selfSchedulingId) return;
+    setPrevActiveId(activeSnapshotId);
     const result = await dispatch(
       activateSnapshot({ selfSchedulingId, snapshotId })
     );
@@ -44,6 +47,7 @@ export default function Snapshots({
           loading={snapshotStatus === "loading"}
           snapshots={snapshots}
           activeSnapshotId={activeSnapshotId}
+          previousActiveId={prevActiveId}
           onAddSnapshot={handleAddSnapshot}
           onActivateSnapshot={handleActivateSnapshot}
           canAddSnapshot={snapshotStatus !== "loading"}

--- a/src/index.css
+++ b/src/index.css
@@ -788,3 +788,16 @@ span.flatpickr-weekday,
 .flash-update {
   animation: item-flash 2s ease-out;
 }
+
+@keyframes move-to-top {
+  from {
+    transform: translateY(var(--slide-distance));
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.move-top {
+  animation: move-to-top 0.3s ease-out;
+}


### PR DESCRIPTION
## Summary
- move active snapshot to the top of the list when activated
- highlight previous active snapshot
- animate snapshot tab when moving

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866280e29f4832791cf01e38c92141a