### PR TITLE
Fix snapshot slices and caching

### DIFF
--- a/src/components/form/DateRangePicker.jsx
+++ b/src/components/form/DateRangePicker.jsx
@@ -18,15 +18,16 @@ export default function MyDateRangePicker({
       flatPickr.current = flatpickr(node, {
         mode: "range",
         dateFormat: "Y-m-d",
+        locale: null,
         static: true,
         defaultDate: [value.startDate, value.endDate],
         minDate: minDate ? minDate.toISOString().split("T")[0] : undefined,
         maxDate: maxDate ? maxDate.toISOString().split("T")[0] : undefined,
         showMonths: 2,
         closeOnSelect: false,
-        onChange: (selectedDates, dateStr) => {
-          const [start, end] = selectedDates;
-          onChange?.({ startDate: start, endDate: end }, dateStr);
+        onChange: (selectedDates, dateStr) => { 
+          const utcMidnights = selectedDates.map((d) => new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())));
+          onChange?.({ startDate: utcMidnights[0], endDate: utcMidnights[1] }, dateStr);
           if (selectedDates.length === 2) {
             flatPickr.current.close();
           }
@@ -36,14 +37,10 @@ export default function MyDateRangePicker({
   }, []);
   useEffect(() => {
     if (flatPickr.current) {
-      flatPickr.current.setDate(
-        [parseDate(value.startDate), parseDate(value.endDate)],
-        false
-      );
+      flatPickr.current.setDate([parseDate(value.startDate), parseDate(value.endDate)], false);
     }
   }, [value.startDate, value.endDate]);
-  const formatDate = (date) =>
-    date instanceof Date ? date.toISOString().split("T")[0] : "";
+  const formatDate = (date) => (date instanceof Date ? date.toISOString().split("T")[0] : "");
 
   const parseDate = (str) => (str ? new Date(str) : null);
 

--- a/src/components/snapshot/SnapshotsContainer.jsx
+++ b/src/components/snapshot/SnapshotsContainer.jsx
@@ -7,7 +7,7 @@ import { fetchSelfschedulingDetails } from "../../store/selfschedulingDetailsSli
 import EmptySnapshotWidget from "./EmptySnapshotWidget.jsx";
 import SnapshotList from "./list/SnapshotList.jsx";
 
-export default function SnapshotsContainer({ snapshots, activeSnapshotId, snapshotStatus, selfSchedulingId }) {
+export default function SnapshotsContainer({ snapshotList, activeSnapshotId, snapshotStatus, selfSchedulingId }) {
   const dispatch = useDispatch();
 
   const handleAddSnapshot = async (label) => {
@@ -21,7 +21,7 @@ export default function SnapshotsContainer({ snapshots, activeSnapshotId, snapsh
     if (!selfSchedulingId) return;
     const result = await dispatch(activateSnapshot({ selfSchedulingId, snapshotId }));
     if (activateSnapshot.fulfilled.match(result)) {
-      dispatch(fetchSelfSchedulingDetails(selfSchedulingId));
+      dispatch(fetchSelfschedulingDetails(selfSchedulingId));
     }
   };
   const handleGenerateSlots = async (snapshotId) => {
@@ -40,13 +40,13 @@ export default function SnapshotsContainer({ snapshots, activeSnapshotId, snapsh
         </div>
       }
     >
-      {snapshots &&
-        (snapshots.length === 0 ? (
+      {snapshotList &&
+        (snapshotList.length === 0 ? (
           <EmptySnapshotWidget onAddSnapshot={handleAddSnapshot} />
         ) : (
           <SnapshotList
             loading={snapshotStatus === "loading"}
-            snapshots={snapshots.list}
+            snapshots={snapshotList}
             activeSnapshotId={activeSnapshotId}
             onAddSnapshot={handleAddSnapshot}
             onActivateSnapshot={handleActivateSnapshot}

--- a/src/components/snapshot/list/SnapshotList.jsx
+++ b/src/components/snapshot/list/SnapshotList.jsx
@@ -24,8 +24,7 @@ export default function SnapshotList({
   useEffect(() => {
     if (!snapshots?.length) return;
     console.log("SnapshotList useEffect - snapshots:", snapshots);
-    const tabs = snapshots.map((x) => {
-      const s = x[1];
+    const tabs = snapshots.map((s) => {
       const isActive = s.snapshotId === activeSnapshotId;
       const { snapshotDate, label, createdAt } = s;
       return {

--- a/src/components/snapshot/selectedSnapshot/SnapshotDetails.jsx
+++ b/src/components/snapshot/selectedSnapshot/SnapshotDetails.jsx
@@ -10,20 +10,20 @@ import SnapshotDetailsTitle from "./SnapshotDetailsTitle.jsx";
 import Tabs from "../../common/Tabs.jsx";
 
 export default function SnapshotDetails({ snapshotId, isActive, loading, onActivateSnapshot, onGenerateSlots }) {
-  useEffect(() => {
-    console.log("SnapshotDetails useEffect", snapshotId);
-    if (snapshotId) {
-      dispatch(fetchSnapshotDetails(snapshotId));
-    }
-  }, [snapshotId]);
   const dispatch = useDispatch();
   const [tabs, setTabs] = useState(null);
   const { details, status } = useSelector((state) => state.snapshots);
-  const { snapshotSummary, tours } = details;
-  const { snapshotDate } = snapshotSummary;
+  const snapshotData = details ? details[snapshotId] : null;
+
   useEffect(() => {
-    console.log("SnapshotDetails useEffect - fetching details for snapshotId:", snapshotId);
-    dispatch(fetchSnapshotDetails(snapshotId));
+    if (snapshotId) {
+      dispatch(fetchSnapshotDetails(snapshotId));
+    }
+  }, [snapshotId, dispatch]);
+
+  useEffect(() => {
+    if (!snapshotData) return;
+    const { tours } = snapshotData;
     const tabs = [
       {
         label: "Tours",
@@ -43,29 +43,34 @@ export default function SnapshotDetails({ snapshotId, isActive, loading, onActiv
       },
     ];
     setTabs(tabs);
-  }, [snapshotId]);
+  }, [snapshotData]);
 
-  if (loading && status === "loading") {
+  if (loading && status === "loading" && !snapshotData) {
     return <Spinner fullscreen />;
-  } else {
-    return (
-      <>
-        <ComponentCard
-          title={
-            <SnapshotDetailsTitle
-              snapshotDate={snapshotDate}
-              isActive={isActive}
-              createdAt={snapshotSummary.createdAt}
-              canGenerateSlots={true}
-              onActivateSnapshot={onActivateSnapshot}
-              onGenerateSlots={onGenerateSlots}
-            />
-          }
-        >
-          <SnapshotOverview isActive={isActive} snapshotSummary={snapshotSummary}></SnapshotOverview>
-          {tabs && <Tabs tabsData={tabs} className="mt-4"></Tabs>}
-        </ComponentCard>
-      </>
-    );
   }
+
+  if (!snapshotData) return null;
+
+  const { snapshotSummary } = snapshotData;
+  const { snapshotDate } = snapshotSummary;
+
+  return (
+    <>
+      <ComponentCard
+        title={
+          <SnapshotDetailsTitle
+            snapshotDate={snapshotDate}
+            isActive={isActive}
+            createdAt={snapshotSummary.createdAt}
+            canGenerateSlots={true}
+            onActivateSnapshot={onActivateSnapshot}
+            onGenerateSlots={onGenerateSlots}
+          />
+        }
+      >
+        <SnapshotOverview isActive={isActive} snapshotSummary={snapshotSummary}></SnapshotOverview>
+        {tabs && <Tabs tabsData={tabs} className="mt-4"></Tabs>}
+      </ComponentCard>
+    </>
+  );
 }

--- a/src/pages/SelfSchedulingPages/SelfSchedulingDetailsPage.jsx
+++ b/src/pages/SelfSchedulingPages/SelfSchedulingDetailsPage.jsx
@@ -16,8 +16,8 @@ export default function SelfSchedulingDetailsPage() {
   const navigate = useNavigate();
 
   const { isSimulationRunning } = useSelector((state) => state.selfschedulings);
-  const selfscheduling = useSelector((state) => state.selfschedulingDetails);
-  const { status, error } = selfscheduling;
+  const selfschedulingState = useSelector((state) => state.selfschedulingDetails);
+  const { status, error, selfscheduling } = selfschedulingState;
   const [actionLoading, setActionLoading] = useState(false);
 
   const snapshots = useSelector((state) => state.snapshots);
@@ -27,9 +27,9 @@ export default function SelfSchedulingDetailsPage() {
 
   const handleAction = async (action) => {
     setActionLoading(true);
-    const result = await dispatch(performConfigurationAction({ id, action }));
+    const result = await dispatch(performSelfschedulingAction({ id, action }));
     if (performSelfschedulingAction.fulfilled.match(result)) {
-      dispatch(fetchSelfscheduling(id));
+      dispatch(fetchSelfschedulingDetails(id));
     }
     setActionLoading(false);
   };
@@ -129,8 +129,8 @@ export default function SelfSchedulingDetailsPage() {
             {status === "succeeded" && snapshots && (
               <SnapshotsContainer
                 activeSnapshotId={selfscheduling.activeSnapshotId}
-                snapshotStatus={status === "succeeded"}
-                snapshots={snapshots}
+                snapshotStatus={snapshots.status}
+                snapshotList={snapshots.list}
                 selfSchedulingId={selfscheduling.selfSchedulingId}
               />
             )}

--- a/src/store/selfschedulingDetailsSlice.js
+++ b/src/store/selfschedulingDetailsSlice.js
@@ -103,7 +103,7 @@ export const activateSnapshot = createAsyncThunk(
 const selfschedulingDetailsSlice = createSlice({
   name: "selfschedulingDetails",
   initialState: {
-    snapshots: [],
+    selfscheduling: null,
     status: "idle",
     error: "",
   },
@@ -115,17 +115,8 @@ const selfschedulingDetailsSlice = createSlice({
         state.error = "";
       })
       .addCase(fetchSelfschedulingDetails.fulfilled, (state, { payload }) => {
-        return {
-          ...state,
-          status: "succeeded",
-          ...payload.selfscheduling,
-        };
-        // state.status = "succeeded";
-        // state.selfscheduling = payload.selfscheduling; // not inside the state.selfscheduling property but state = payload.selfscheduling won't work
-        // state.snapshots = payload.selfscheduling.snapshots || [];
-        // state.activeSnapshot = payload.selfscheduling.activeSnapshotId;
-        // state.snapshotStatus = "succeeded";
-        // state.snapshotError = "";
+        state.status = "succeeded";
+        state.selfscheduling = payload.selfscheduling;
       })
       .addCase(fetchSelfschedulingDetails.rejected, (state, action) => {
         state.status = "failed";

--- a/src/store/slotsSlice.js
+++ b/src/store/slotsSlice.js
@@ -1,5 +1,8 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 
+const getToken = () => localStorage.getItem("token") || "";
+const backend_url = import.meta.env.REACT_APP_BACKEND_URL || "http://localhost:5005/api/v1";
+
 export const generateSlots = createAsyncThunk("slots/generateSlots", async (selfSchedulingId, { rejectWithValue }) => {
   try {
     const res = await fetch(`${backend_url}/snapshots/slots/${selfSchedulingId}`, {

--- a/src/store/snapshotsSlice.js
+++ b/src/store/snapshotsSlice.js
@@ -41,7 +41,6 @@ export const fetchSnapshotDetails = createAsyncThunk(
   "snapshots/fetchSnapshotDetails",
   async (snapshotId, { rejectWithValue }) => {
     try {
-      debugger;
       const res = await fetch(`${backend_url}/snapshots/${snapshotId}`, {
         headers: { Authorization: `Bearer ${getToken()}` },
       });
@@ -54,9 +53,8 @@ export const fetchSnapshotDetails = createAsyncThunk(
   },
   {
     condition: (snapshotId, { getState }) => {
-      console.log(getState().snapshots.list[snapshotId]);
-      const entry = getState().snapshots.list[snapshotId];
-      return !(entry?.loaded || entry?.loading);
+      const entry = getState().snapshots.details[snapshotId];
+      return !entry;
     },
   }
 );
@@ -64,27 +62,22 @@ export const fetchSnapshotDetails = createAsyncThunk(
 const snapshotsSlice = createSlice({
   name: "snapshots",
   initialState: {
-    list: {},
+    list: [],
     details: {},
     status: "idle",
     error: null,
-    currentSnapshotIndex: 0,
   },
   reducers: {},
   extraReducers: (builder) => {
     builder
       .addCase(fetchSelfschedulingDetails.pending, (state) => {
-        console.log("Fetching self-scheduling details...");
         state.status = "loading";
         state.error = "";
         state.list = [];
       })
       .addCase(fetchSelfschedulingDetails.fulfilled, (state, { payload }) => {
         state.status = "succeeded";
-        state.list = payload.selfscheduling.snapshots.map((s) => [
-          s.snapshotId,
-          { ...s, loading: false, loaded: false },
-        ]); 
+        state.list = payload.selfscheduling.snapshots || [];
         const id = payload.snapshot?.snapshotSummary?.snapshotId;
         if (id) {
           state.details[id] = payload.snapshot;
@@ -94,15 +87,16 @@ const snapshotsSlice = createSlice({
         state.status = "failed";
         state.error = action.payload;
       })
+      .addCase(fetchSnapshotDetails.pending, (state) => {
+        state.status = "loading";
+      })
       .addCase(fetchSnapshotDetails.fulfilled, (state, { payload }) => {
-        state.list[payload.snapshotId] = { loading: false, loaded: true };
+        state.status = "succeeded";
         state.details[payload.snapshotId] = { ...payload.data };
       })
-      .addCase(fetchSnapshotDetails.pending, (state, { meta }) => {
-        state.list[meta.snapshotId] = { loading: true, loaded: false };
-      })
       .addCase(fetchSnapshotDetails.rejected, (state, { payload }) => {
-        state.list[payload.snapshotId] = { loading: false, loaded: false, error: payload.error };
+        state.status = "failed";
+        state.error = payload.error;
       })
       .addCase(createSnapshot.pending, (state) => {
         state.status = "loading";


### PR DESCRIPTION
## Summary
- update selfSchedulingDetails slice to store item under `selfscheduling`
- refactor snapshots slice to keep list array and cached details
- fix snapshot-related components to use new slice shape
- adjust slots slice utilities
- correct actions in SelfSchedulingDetailsPage

## Testing
- `npm run lint` *(fails: NotificationsWidget.jsx line 16 setHistory not defined, AddSelfSchedulingForm.jsx line 42 setCityId not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687ae44df0d08327888ca111d94daec8