### PR TITLE
Add snapshot item generation

### DIFF
--- a/src/components/common/VerticalTabs.jsx
+++ b/src/components/common/VerticalTabs.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 export default function VerticalTabs({ tabsData, addOn, onChangeTab, currentTabIndex }) {
   return (
     <div className="flex flex-col gap-6 sm:flex-row sm:gap-8 rounded-xl">
-      <div className="sm:w-[300px] rounded-xl p-6 dark:bg-white/[0.03]">
+      <div className="sm:w-[400px] rounded-xl p-6 dark:bg-white/[0.03]">
         {addOn && <div className="pb-6 mb-6 border-b border-gray-700">{addOn}</div>}
         <nav className="flex flex-auto sm:flex-col sm:space-y-2 overflow-y-auto">
           {tabsData.map((tab, idx) => (

--- a/src/components/notifications/NotificationsWidget.jsx
+++ b/src/components/notifications/NotificationsWidget.jsx
@@ -4,7 +4,7 @@ import ComponentCard from "../common/ComponentCard";
 import { eventsData } from "../../utils/constants";
 import { Table, TableBody, TableCell, TableRow } from "../ui/table/index";
 
-export default function NotificationsWidget({ notifications, logs, history }) {
+export default function NotificationsWidget({ notifications, logs, history, setHistory = () => {} }) {
   const { id } = useParams();
 
   useEffect(() => {

--- a/src/components/selfscheduling/AddSelfSchedulingForm.jsx
+++ b/src/components/selfscheduling/AddSelfSchedulingForm.jsx
@@ -18,6 +18,7 @@ export default function AddSelfSchedulingForm({
   setSchedulingWindow,
   toursPeriod,
   setToursPeriod,
+  setCityId,
   handleExperienceChange,
   handleGuideChange,
   selectedExperienceIds,

--- a/src/components/selfscheduling/SelfSchedulingOverview.jsx
+++ b/src/components/selfscheduling/SelfSchedulingOverview.jsx
@@ -7,7 +7,6 @@ import DateRange from "../common/DateRange";
 export default function SelfSchedulingOverview({ selfscheduling, onAction, actionLoading = false }) {
   const { configuration: config, selfSchedulingId: id } = selfscheduling || {};
   const { toursPeriod, schedulingWindow, configurationId: configId } = config || {};
-  console.log(selfscheduling);
   const getDaysLeft = (date) => {
     const today = new Date();
     const target = new Date(date);

--- a/src/components/selfscheduling/SelfSchedulingOverview.jsx
+++ b/src/components/selfscheduling/SelfSchedulingOverview.jsx
@@ -7,6 +7,13 @@ import DateRange from "../common/DateRange";
 export default function SelfSchedulingOverview({ selfscheduling, onAction, actionLoading = false }) {
   const { configuration: config, selfSchedulingId: id } = selfscheduling || {};
   const { toursPeriod, schedulingWindow, configurationId: configId } = config || {};
+  console.log(selfscheduling);
+  const getDaysLeft = (date) => {
+    const today = new Date();
+    const target = new Date(date);
+    const diffMs = target - today;
+    return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  };
   return (
     <div className="p-5 border border-gray-200 rounded-2xl dark:border-gray-800 lg:p-6">
       <div className="flex flex-col gap-4">
@@ -32,7 +39,7 @@ export default function SelfSchedulingOverview({ selfscheduling, onAction, actio
               <div className="text-xs font-medium text-gray-800 dark:text-white/90">
                 <div>{configId}</div>
               </div>
-            </div>{" "}
+            </div>
           </CopyableText>
 
           <div>
@@ -45,8 +52,8 @@ export default function SelfSchedulingOverview({ selfscheduling, onAction, actio
             <div className="flex items-center mb-2">
               <div className=" text-xs leading-normal text-gray-500 dark:text-gray-400 mr-5">Scheduling Window</div>
               <div>
-                <Badge variant="light" size="sm" color={selfscheduling.isRunning ? "success" : "warning"}>
-                  {selfscheduling.isRunning ? "Running" : "Pending"}
+                <Badge variant="light" size="sm" color={selfscheduling.isRunning ? "success" : "info"}>
+                  {selfscheduling.isRunning ? "Running" : getDaysLeft(schedulingWindow.start) + " days left"}
                 </Badge>
               </div>
             </div>
@@ -56,20 +63,30 @@ export default function SelfSchedulingOverview({ selfscheduling, onAction, actio
               <DateTime date={schedulingWindow.end} />
             </p>
           </div>
-          <div>
-            <div className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">Experiences Count</div>
-            <div className="text-sm font-medium text-gray-800 dark:text-white/90">
-              <Badge variant="solid" size="sm">
-                {config.subject.experienceIds?.length || 0}
-              </Badge>
+          <div className="grid grid-cols-3 col-span-2">
+            <div>
+              <div className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">Experiences Count</div>
+              <div className="text-sm font-medium text-gray-800 dark:text-white/90">
+                <Badge variant="solid" size="sm">
+                  {config.subject.experienceIds?.length || 0}
+                </Badge>
+              </div>
             </div>
-          </div>
-          <div>
-            <div className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">Guides Count</div>
-            <div className="text-sm font-medium text-gray-800 dark:text-white/90">
-              <Badge variant="solid" size="sm">
-                {config.audience.guideIds?.length || 0}
-              </Badge>
+            <div>
+              <div className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">Guides Count</div>
+              <div className="text-sm font-medium text-gray-800 dark:text-white/90">
+                <Badge variant="solid" size="sm">
+                  {config.audience.guideIds?.length || 0}
+                </Badge>
+              </div>
+            </div>
+            <div>
+              <div className="mb-2 text-xs leading-normal text-gray-500 dark:text-gray-400">Snapshots Count</div>
+              <div className="text-sm font-medium text-gray-800 dark:text-white/90">
+                <Badge variant="solid" size="sm">
+                  {selfscheduling.snapshots?.length}
+                </Badge>
+              </div>
             </div>
           </div>
           <div>

--- a/src/components/snapshot/SnapshotsContainer.jsx
+++ b/src/components/snapshot/SnapshotsContainer.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import ComponentCard from "../common/ComponentCard";
 import { useDispatch } from "react-redux";
-import { activateSnapshot, createSnapshot } from "../../store/snapshotsSlice.js";
+import { activateSnapshot, createSnapshot, processSnapshot } from "../../store/snapshotsSlice.js";
 import { generateSlots } from "../../store/slotsSlice.js";
 import { fetchSelfschedulingDetails } from "../../store/selfschedulingDetailsSlice.js";
 import EmptySnapshotWidget from "./EmptySnapshotWidget.jsx";
@@ -32,6 +32,13 @@ export default function SnapshotsContainer({ snapshotList, activeSnapshotId, sna
       dispatch(fetchSelfschedulingDetails(selfSchedulingId));
     }
   };
+  const handleGenerateItems = async (snapshotId) => {
+    if (!snapshotId) return;
+    const result = await dispatch(processSnapshot(snapshotId));
+    if (processSnapshot.fulfilled.match(result)) {
+      dispatch(fetchSelfschedulingDetails(selfSchedulingId));
+    }
+  };
   return (
     <ComponentCard
       title={
@@ -51,6 +58,7 @@ export default function SnapshotsContainer({ snapshotList, activeSnapshotId, sna
             onAddSnapshot={handleAddSnapshot}
             onActivateSnapshot={handleActivateSnapshot}
             onGenerateSlots={handleGenerateSlots}
+            onGenerateItems={handleGenerateItems}
             canAddSnapshot={snapshotStatus !== "loading"}
           />
         ))}

--- a/src/components/snapshot/SnapshotsContainer.jsx
+++ b/src/components/snapshot/SnapshotsContainer.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import ComponentCard from "../common/ComponentCard";
 import { useDispatch } from "react-redux";
 import { activateSnapshot, createSnapshot, processSnapshot } from "../../store/snapshotsSlice.js";
@@ -9,7 +9,8 @@ import SnapshotList from "./list/SnapshotList.jsx";
 
 export default function SnapshotsContainer({ snapshotList, activeSnapshotId, snapshotStatus, selfSchedulingId }) {
   const dispatch = useDispatch();
-
+  debugger;
+  const [selectedSnapshot, setSelectedSnasphot] = useState(activeSnapshotId || null);
   const handleAddSnapshot = async (label) => {
     if (!selfSchedulingId) return;
     const result = await dispatch(createSnapshot({ selfSchedulingId, label }));
@@ -17,7 +18,7 @@ export default function SnapshotsContainer({ snapshotList, activeSnapshotId, sna
       dispatch(fetchSelfschedulingDetails(selfSchedulingId));
     }
   };
-  const handleActivateSnapshot = async (snapshotId) => { 
+  const handleActivateSnapshot = async (snapshotId) => {
     if (!selfSchedulingId) return;
     const result = await dispatch(activateSnapshot({ selfSchedulingId, snapshotId }));
     if (activateSnapshot.fulfilled.match(result)) {
@@ -55,6 +56,8 @@ export default function SnapshotsContainer({ snapshotList, activeSnapshotId, sna
             loading={snapshotStatus === "loading"}
             snapshots={snapshotList}
             activeSnapshotId={activeSnapshotId}
+            selectedSnapshot={selectedSnapshot}
+            onSnapshotSelected={(id) => setSelectedSnasphot(id)}
             onAddSnapshot={handleAddSnapshot}
             onActivateSnapshot={handleActivateSnapshot}
             onGenerateSlots={handleGenerateSlots}

--- a/src/components/snapshot/list/SnapshotList.jsx
+++ b/src/components/snapshot/list/SnapshotList.jsx
@@ -16,6 +16,7 @@ export default function SnapshotList({
   loading,
   onActivateSnapshot,
   onGenerateSlots,
+  onGenerateItems,
 }) {
   const [tabsData, setTabsData] = useState(null);
   const [snapshotLabel, setSnapshotLabel] = useState("Generated from Dashboard");
@@ -50,6 +51,7 @@ export default function SnapshotList({
             loading={loading}
             onActivateSnapshot={() => onActivateSnapshot(s.snapshotId)}
             onGenerateSlots={() => onGenerateSlots(s.snapshotId)}
+            onGenerateItems={() => onGenerateItems(s.snapshotId)}
             isActive={isActive}
             snapshotId={s.snapshotId}
           />

--- a/src/components/snapshot/list/SnapshotList.jsx
+++ b/src/components/snapshot/list/SnapshotList.jsx
@@ -10,34 +10,41 @@ import Label from "../../form/Label.jsx";
 import DateTime from "../../common/DateTime.jsx";
 export default function SnapshotList({
   snapshots,
+  selectedSnapshot,
   activeSnapshotId,
   onAddSnapshot,
   canAddSnapshot,
   loading,
   onActivateSnapshot,
-  onGenerateSlots,
   onGenerateItems,
+  onSnapshotSelected,
 }) {
   const [tabsData, setTabsData] = useState(null);
   const [snapshotLabel, setSnapshotLabel] = useState("Generated from Dashboard");
-  const [currentTabIndex, setCurrentTabIndex] = useState(0);
-  //const { details, status } = useSelector((state) => state.snapshots);
+  var elementPos = snapshots
+    .map(function (x) {
+      return x.snapshotId;
+    })
+    .indexOf(selectedSnapshot);
+  const [currentTabIndex, setCurrentTabIndex] = useState(elementPos || 0);
   useEffect(() => {
     if (!snapshots?.length) return;
-    console.log("SnapshotList useEffect - snapshots:", snapshots);
     const tabs = snapshots.map((s) => {
-      const isActive = s.snapshotId === activeSnapshotId;
       const { snapshotDate, label, createdAt } = s;
+      const isActive = s.snapshotId === activeSnapshotId;
       return {
         isActive,
         label: (
           <div className="flex flex-row w-full justify-between items-center">
             <div className="flex-auto text-left">
-              <div className="text-sm">{snapshotDate}</div>
-              <div className="text-xs">{label}</div>
-              <div className="text-xs">
+              <div className="text-theme-sm mb-2">
+                <DateTime date={snapshotDate} />
+                <span className="ml-1">- {label}</span>
+              </div>
+              <div className="text-theme-xs">
                 <DateTime date={createdAt} />
               </div>
+              <div className="text-theme-xs">{s.snapshotId}</div>
             </div>
             {isActive && (
               <div className="text-right text-lg">
@@ -50,17 +57,16 @@ export default function SnapshotList({
           <SnapshotDetails
             loading={loading}
             onActivateSnapshot={() => onActivateSnapshot(s.snapshotId)}
-            onGenerateSlots={() => onGenerateSlots(s.snapshotId)}
             onGenerateItems={() => onGenerateItems(s.snapshotId)}
             isActive={isActive}
-            snapshotId={s.snapshotId}
+            snapshotId={selectedSnapshot}
           />
         ),
       };
     });
-    console.log("SnapshotList useEffect - tabsData:", tabs);
+    console.log("here");
     setTabsData(tabs);
-  }, [snapshots, activeSnapshotId, loading, currentTabIndex]);
+  }, [activeSnapshotId, loading]);
 
   const addOn = (
     <>
@@ -96,7 +102,7 @@ export default function SnapshotList({
           currentTabIndex={currentTabIndex}
           tabsData={tabsData}
           addOn={addOn}
-          onChangeTab={(idx) => setCurrentTabIndex(idx)}
+          onChangeTab={onSnapshotSelected}
         ></VerticalTabs>
       )}
     </>

--- a/src/components/snapshot/selectedSnapshot/SnapshotDetails.jsx
+++ b/src/components/snapshot/selectedSnapshot/SnapshotDetails.jsx
@@ -6,10 +6,18 @@ import Spinner from "../../ui/spinner/Spinner.jsx";
 import ComponentCard from "../../common/ComponentCard.jsx";
 import TourSnapshots from "./tabs/TourSnapshots.jsx";
 import ForecastSnapshots from "./tabs/ForecastSnapshots.jsx";
+import ItemsSnapshots from "./tabs/ItemsSnapshots.jsx";
 import SnapshotDetailsTitle from "./SnapshotDetailsTitle.jsx";
 import Tabs from "../../common/Tabs.jsx";
 
-export default function SnapshotDetails({ snapshotId, isActive, loading, onActivateSnapshot, onGenerateSlots }) {
+export default function SnapshotDetails({
+  snapshotId,
+  isActive,
+  loading,
+  onActivateSnapshot,
+  onGenerateSlots,
+  onGenerateItems,
+}) {
   const dispatch = useDispatch();
   const [tabs, setTabs] = useState(null);
   const { details, status } = useSelector((state) => state.snapshots);
@@ -23,7 +31,7 @@ export default function SnapshotDetails({ snapshotId, isActive, loading, onActiv
 
   useEffect(() => {
     if (!snapshotData) return;
-    const { tours } = snapshotData;
+    const { tours, items } = snapshotData;
     const tabs = [
       {
         label: "Tours",
@@ -32,6 +40,10 @@ export default function SnapshotDetails({ snapshotId, isActive, loading, onActiv
       {
         label: "Forecasting",
         content: <ForecastSnapshots tours={tours} />,
+      },
+      {
+        label: "Items",
+        content: <ItemsSnapshots items={items || []} />,
       },
       {
         label: "Guides",
@@ -65,6 +77,7 @@ export default function SnapshotDetails({ snapshotId, isActive, loading, onActiv
             canGenerateSlots={true}
             onActivateSnapshot={onActivateSnapshot}
             onGenerateSlots={onGenerateSlots}
+            onGenerateItems={onGenerateItems}
           />
         }
       >

--- a/src/components/snapshot/selectedSnapshot/SnapshotDetails.jsx
+++ b/src/components/snapshot/selectedSnapshot/SnapshotDetails.jsx
@@ -1,70 +1,51 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchSnapshotDetails } from "../../../store/snapshotsSlice.js";
 import SnapshotOverview from "./SnapshotOverview.jsx";
 import Spinner from "../../ui/spinner/Spinner.jsx";
 import ComponentCard from "../../common/ComponentCard.jsx";
 import TourSnapshots from "./tabs/TourSnapshots.jsx";
 import ForecastSnapshots from "./tabs/ForecastSnapshots.jsx";
-import ItemsSnapshots from "./tabs/ItemsSnapshots.jsx";
+import SelfSchedulingItems from "./tabs/SelfSchedulingItems.jsx";
 import SnapshotDetailsTitle from "./SnapshotDetailsTitle.jsx";
 import Tabs from "../../common/Tabs.jsx";
 
-export default function SnapshotDetails({
-  snapshotId,
-  isActive,
-  loading,
-  onActivateSnapshot,
-  onGenerateSlots,
-  onGenerateItems,
-}) {
-  const dispatch = useDispatch();
+export default function SnapshotDetails({ snapshotId, isActive, loading, onActivateSnapshot, onGenerateItems }) {
   const [tabs, setTabs] = useState(null);
   const { details, status } = useSelector((state) => state.snapshots);
-  const snapshotData = details ? details[snapshotId] : null;
+  const snapshot = details ? details[snapshotId] : null;
+  const { tours, snapshotSummary } = snapshot;
+  const { snapshotDate } = snapshotSummary;
 
   useEffect(() => {
-    if (snapshotId) {
-      dispatch(fetchSnapshotDetails(snapshotId));
-    }
-  }, [snapshotId, dispatch]);
-
-  useEffect(() => {
-    if (!snapshotData) return;
-    const { tours, items } = snapshotData;
     const tabs = [
       {
         label: "Tours",
-        content: <TourSnapshots tours={tours} />,
+        content: <TourSnapshots snapshotId={snapshotId} />,
       },
-      {
-        label: "Forecasting",
-        content: <ForecastSnapshots tours={tours} />,
-      },
-      {
-        label: "Items",
-        content: <ItemsSnapshots items={items || []} />,
-      },
-      {
-        label: "Guides",
-        content: <span>Guides</span>,
-      },
-      {
-        label: "Allocations",
-        content: <span>Allocations</span>,
-      },
+      // {
+      //   label: "Forecasting",
+      //   content: <ForecastSnapshots tours={tours} />,
+      // },
+      // {
+      //   label: "Items",
+      //   content: <SelfSchedulingItems snapshotId={snapshotId} />,
+      // },
+      // {
+      //   label: "Guides",
+      //   content: <span>Guides</span>,
+      // },
+      // {
+      //   label: "Allocations",
+      //   content: <span>Allocations</span>,
+      // },
     ];
+    console.log("snapshotid changed")
     setTabs(tabs);
-  }, [snapshotData]);
+  }, [snapshotId]);
 
   if (loading && status === "loading" && !snapshotData) {
     return <Spinner fullscreen />;
   }
-
-  if (!snapshotData) return null;
-
-  const { snapshotSummary } = snapshotData;
-  const { snapshotDate } = snapshotSummary;
 
   return (
     <>
@@ -76,7 +57,6 @@ export default function SnapshotDetails({
             createdAt={snapshotSummary.createdAt}
             canGenerateSlots={true}
             onActivateSnapshot={onActivateSnapshot}
-            onGenerateSlots={onGenerateSlots}
             onGenerateItems={onGenerateItems}
           />
         }

--- a/src/components/snapshot/selectedSnapshot/SnapshotDetailsTitle.jsx
+++ b/src/components/snapshot/selectedSnapshot/SnapshotDetailsTitle.jsx
@@ -1,13 +1,6 @@
 import DateTime from "../../common/DateTime";
 import MoreMenu from "../../common/MoreMenu";
-export default function SnapshotDetailsTitle({
-  snapshotDate,
-  isActive,
-  canGenerateSlots,
-  onActivateSnapshot,
-  onGenerateSlots,
-  onGenerateItems,
-}) {
+export default function SnapshotDetailsTitle({ snapshotDate, isActive, onActivateSnapshot, onGenerateItems }) {
   return (
     <div className="flex justify-between">
       <div>
@@ -19,7 +12,6 @@ export default function SnapshotDetailsTitle({
       <MoreMenu
         menuItems={[
           { label: "Activate", action: onActivateSnapshot, disabled: !isActive },
-          { label: "Generate Slots", action: onGenerateSlots, disabled: !canGenerateSlots },
           { label: "Generate Items", action: onGenerateItems },
         ]}
       />

--- a/src/components/snapshot/selectedSnapshot/SnapshotDetailsTitle.jsx
+++ b/src/components/snapshot/selectedSnapshot/SnapshotDetailsTitle.jsx
@@ -6,6 +6,7 @@ export default function SnapshotDetailsTitle({
   canGenerateSlots,
   onActivateSnapshot,
   onGenerateSlots,
+  onGenerateItems,
 }) {
   return (
     <div className="flex justify-between">
@@ -19,6 +20,7 @@ export default function SnapshotDetailsTitle({
         menuItems={[
           { label: "Activate", action: onActivateSnapshot, disabled: !isActive },
           { label: "Generate Slots", action: onGenerateSlots, disabled: !canGenerateSlots },
+          { label: "Generate Items", action: onGenerateItems },
         ]}
       />
     </div>

--- a/src/components/snapshot/selectedSnapshot/SnapshotOverview.jsx
+++ b/src/components/snapshot/selectedSnapshot/SnapshotOverview.jsx
@@ -1,7 +1,7 @@
 import ComponentCard from "../../common/ComponentCard";
 import CopyableText from "../../common/CopyableText";
 import DateTime from "../../common/DateTime";
-export default function SnapshotOverview({ snapshotSummary, isActive, onActivateSnapshot }) {
+export default function SnapshotOverview({ snapshotSummary, isActive }) {
   const title = (
     <div className="flex relative items-center">
       <div className="flex-1 h-[32px]">{snapshotSummary.label}</div>

--- a/src/components/snapshot/selectedSnapshot/tabs/ItemsSnapshots.jsx
+++ b/src/components/snapshot/selectedSnapshot/tabs/ItemsSnapshots.jsx
@@ -1,0 +1,43 @@
+import { Table, TableHeader, TableBody, TableRow, TableCell, TableCellHeader } from "../../../ui/table/index";
+import TourId from "../../../common/TourId";
+export default function ItemsSnapshots({ items }) {
+  if (!items) return null;
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
+      <div className="max-w-full overflow-x-auto">
+        <Table>
+          <TableHeader className="border-b border-gray-100 dark:border-white/[0.05]">
+            <TableRow>
+              <TableCellHeader>
+                <div className="flex flex-col items-start">
+                  <div>[ExpId-OptId] - Experience</div>
+                  <div>Option</div>
+                </div>
+              </TableCellHeader>
+              <TableCellHeader>Date</TableCellHeader>
+              <TableCellHeader>Time</TableCellHeader>
+              <TableCellHeader>Day</TableCellHeader>
+              <TableCellHeader>Initial Slots</TableCellHeader>
+            </TableRow>
+          </TableHeader>
+          <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05] text-sm">
+            {items.map((i) => (
+              <TableRow key={i.id} className="hover:bg-gray-50 dark:hover:bg-white/[0.05]">
+                <TableCell className="px-5 py-2">
+                  <div className="text-xs">
+                    <TourId tourId={i.tourId} /> <span className="ml-2">{i.name.experienceName}</span>
+                  </div>
+                  <div className="font-medium text-gray-800 dark:text-white/90">{i.name.optionName}</div>
+                </TableCell>
+                <TableCell className="px-5 py-2">{i.tourDate}</TableCell>
+                <TableCell className="px-5 py-2">{i.tourTime}</TableCell>
+                <TableCell className="px-5 py-2">{i.dayCategory}</TableCell>
+                <TableCell className="px-5 py-2">{i.initialSlotsAvailability}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/snapshot/selectedSnapshot/tabs/SelfSchedulingItems.jsx
+++ b/src/components/snapshot/selectedSnapshot/tabs/SelfSchedulingItems.jsx
@@ -1,8 +1,18 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { Table, TableHeader, TableBody, TableRow, TableCell, TableCellHeader } from "../../../ui/table/index";
+import { fetchItems } from "../../../../store/snapshotsSlice";
 import TourId from "../../../common/TourId";
-export default function ItemsSnapshots({ items }) {
-  if (!items) return null;
-  return (
+
+export default function SelfSchedulingItems({ snapshotId }) {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchItems(snapshotId));
+  }, [snapshotId]);
+  const items = useSelector((state) => state.snapshots.details[snapshotId].items) || [];
+  const status = useSelector((state) => state.snapshots.status);
+  console.log(items);
+  return status === "succeeded" ? (
     <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
       <div className="max-w-full overflow-x-auto">
         <Table>
@@ -39,5 +49,7 @@ export default function ItemsSnapshots({ items }) {
         </Table>
       </div>
     </div>
+  ) : (
+    <span>x</span>
   );
 }

--- a/src/components/snapshot/selectedSnapshot/tabs/TourSnapshots.jsx
+++ b/src/components/snapshot/selectedSnapshot/tabs/TourSnapshots.jsx
@@ -1,7 +1,19 @@
+import { useEffect } from "react";
 import { Table, TableHeader, TableBody, TableRow, TableCell, TableCellHeader } from "../../../ui/table/index";
 import DateRange from "../../../common/DateRange";
 import TourId from "../../../common/TourId";
-export default function TourSnapshots({ tours }) {
+import { useDispatch, useSelector } from "react-redux";
+import { fetchTourSnapshots } from "../../../../store/snapshotsSlice";
+export default function TourSnapshots({ snapshotId }) {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (snapshotId) {
+      console.log("here");
+        dispatch(fetchTourSnapshots(snapshotId));
+    }
+  }, [snapshotId]);
+  const { details, status } = useSelector((state) => state.snapshots);
+  const tours = details[snapshotId] ? details[snapshotId].tours : null;
   const renderOccurrences = (occurrences) => {
     return occurrences.map((o) => {
       return (
@@ -22,7 +34,7 @@ export default function TourSnapshots({ tours }) {
                   <div>[ExpId-OptId] - Experience</div>
                   <div>Option</div>
                 </div>
-              </TableCellHeader> 
+              </TableCellHeader>
               <TableCellHeader>Group Size</TableCellHeader>
               <TableCellHeader>
                 <div className="flex flex-col items-start">
@@ -33,18 +45,20 @@ export default function TourSnapshots({ tours }) {
             </TableRow>
           </TableHeader>
           <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05] text-sm">
-            {tours.map((t) => (
-              <TableRow key={`${t.tourId.optionId}`} className="hover:bg-gray-50 dark:hover:bg-white/[0.05]">
-                <TableCell className="px-5 py-2">
-                  <div className="text-xs">
-                    <TourId tourId={t.tourId} /> <span className="ml-2">{t.name.experienceName}</span>
-                  </div>
-                  <div className="font-medium text-gray-800 dark:text-white/90">{t.name.optionName}</div>
-                </TableCell>
-                <TableCell className="px-5 py-2">{t.groupSize}</TableCell>
-                <TableCell className="px-5 py-2">{renderOccurrences(t.tourOccurrences)}</TableCell>
-              </TableRow>
-            ))}
+            {status === "succeeded" &&
+              tours &&
+              tours.map((t) => (
+                <TableRow key={`${t.tourId.optionId}`} className="hover:bg-gray-50 dark:hover:bg-white/[0.05]">
+                  <TableCell className="px-5 py-2">
+                    <div className="text-xs">
+                      <TourId tourId={t.tourId} /> <span className="ml-2">{t.name.experienceName}</span>
+                    </div>
+                    <div className="font-medium text-gray-800 dark:text-white/90">{t.name.optionName}</div>
+                  </TableCell>
+                  <TableCell className="px-5 py-2">{t.groupSize}</TableCell>
+                  <TableCell className="px-5 py-2">{renderOccurrences(t.tourOccurrences)}</TableCell>
+                </TableRow>
+              ))}
           </TableBody>
         </Table>
       </div>

--- a/src/components/snapshot/selectedSnapshot/tabs/TourSnapshots.jsx
+++ b/src/components/snapshot/selectedSnapshot/tabs/TourSnapshots.jsx
@@ -22,14 +22,14 @@ export default function TourSnapshots({ tours }) {
                   <div>[ExpId-OptId] - Experience</div>
                   <div>Option</div>
                 </div>
-              </TableCellHeader>
+              </TableCellHeader> 
+              <TableCellHeader>Group Size</TableCellHeader>
               <TableCellHeader>
                 <div className="flex flex-col items-start">
                   <div>Occurrences overlapping SelfScheduling Tours Period </div>
                   <div>From - To</div>
                 </div>
               </TableCellHeader>
-              <TableCellHeader>Group Size</TableCellHeader>
             </TableRow>
           </TableHeader>
           <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05] text-sm">
@@ -41,8 +41,8 @@ export default function TourSnapshots({ tours }) {
                   </div>
                   <div className="font-medium text-gray-800 dark:text-white/90">{t.name.optionName}</div>
                 </TableCell>
-                <TableCell className="px-5 py-2">{renderOccurrences(t.tourOccurrences)}</TableCell>
                 <TableCell className="px-5 py-2">{t.groupSize}</TableCell>
+                <TableCell className="px-5 py-2">{renderOccurrences(t.tourOccurrences)}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/src/pages/SelfSchedulingPages/AddSelfSchedulingPage.jsx
+++ b/src/pages/SelfSchedulingPages/AddSelfSchedulingPage.jsx
@@ -206,6 +206,7 @@ export default function AddSelfSchedulingPage() {
           <AddSelfSchedulingForm
             cityId={cityId}
             cities={cities}
+            setCityId={setCityId}
             description={description}
             setDescription={setDescription}
             schedulingWindow={schedulingWindow}

--- a/src/pages/SelfSchedulingPages/SelfSchedulingDetailsPage.jsx
+++ b/src/pages/SelfSchedulingPages/SelfSchedulingDetailsPage.jsx
@@ -85,7 +85,7 @@ export default function SelfSchedulingDetailsPage() {
                 </svg>
               </Link>
             </li>
-            <li className="text-sm text-gray-800 dark:text-white/90">Configuration Details</li>
+            <li className="text-sm text-gray-800 dark:text-white/90">SelfScheduling Details</li>
           </ol>
         </nav>
       </div>

--- a/src/store/selfschedulingDetailsSlice.js
+++ b/src/store/selfschedulingDetailsSlice.js
@@ -134,17 +134,6 @@ const selfschedulingDetailsSlice = createSlice({
         state.slotsStatus = "failed";
         state.slotsError = action.payload;
       })
-      // .addCase(createSnapshot.pending, (state) => {
-      //   state.snapshotStatus = "loading";
-      //   state.snapshotError = "";
-      // })
-      // .addCase(createSnapshot.fulfilled, (state) => {
-      //   state.snapshotStatus = "succeeded";
-      // })
-      // .addCase(createSnapshot.rejected, (state, action) => {
-      //   state.snapshotStatus = "failed";
-      //   state.snapshotError = action.payload;
-      // })
       .addCase(activateSnapshot.pending, (state) => {
         state.snapshotStatus = "loading";
         state.snapshotError = "";
@@ -159,26 +148,5 @@ const selfschedulingDetailsSlice = createSlice({
       .addCase(performSelfschedulingAction.fulfilled, (state, { payload }) => {
         state.config = payload;
       }),
-  // .addCase(fetchSnapshotDetails.pending, (state, { meta }) => {
-  //   state.snapshotsDetails[meta.arg] = {
-  //     loading: true,
-  //     loaded: false,
-  //     data: state.snapshotsDetails[meta.arg]?.data,
-  //   };
-  // })
-  // .addCase(fetchSnapshotDetails.fulfilled, (state, { payload }) => {
-  //   state.snapshotsDetails[payload.snapshotId] = {
-  //     loading: false,
-  //     loaded: true,
-  //     data: payload.data,
-  //   };
-  // })
-  // .addCase(fetchSnapshotDetails.rejected, (state, { meta }) => {
-  //   state.snapshotsDetails[meta.arg] = {
-  //     loading: false,
-  //     loaded: false,
-  //     data: undefined,
-  //   };
-  // }),
 });
 export default selfschedulingDetailsSlice.reducer;


### PR DESCRIPTION
## Summary
- allow city selection in add form
- process snapshot items via snapshot slice
- wire new generate items action through snapshots components
- show items on a new tab
- fix lint issues

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bf8c7af688327a1b028effdabaefa